### PR TITLE
Allow local execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ data/repo_network.csv
 data/readmes/*.md
 data/*/*.txt
 plots/
+data/gharchive/
+data/_checkpoints/
+.venv/

--- a/README.md
+++ b/README.md
@@ -55,9 +55,15 @@ The scripts works with Python 3.12 and has only been tested on Ubuntu 22.04.
 
 ## Running the Detector
 
-The detector employs two heuristics: a low-activity heuristic and a lockstep heuristic. Their parameters are defined in [scripts/__init__.py](scripts/__init__.py). Notably, you may wnat to change the `END_DATE` and `COPYCATCH_DATE_CHUNKS` to include latest data. The CopyCatch algorithm for the lockstep heuristic works on half-year chunks as specified in `COPYCATCH_DATE_CHUNKS` and a new chunk should be manually added on a quarterly basis (e.g., add `("240401", "241001")` after Oct 2024).
+The detector employs two heuristics: a low-activity heuristic and a lockstep heuristic. Their parameters are defined in [scripts/__init__.py](scripts/__init__.py). Notably, you may want to change the `END_DATE` and `COPYCATCH_DATE_CHUNKS` to include latest data. The CopyCatch algorithm for the lockstep heuristic works on half-year chunks as specified in `COPYCATCH_DATE_CHUNKS` and a new chunk should be manually added on a quarterly basis (e.g., add `("240401", "241001")` after Oct 2024).
 
-To run the low-acivity heuristic, use:
+### Local Execution (Alternative)
+
+For cost-effective local execution without Google Cloud, see **[scripts/local/README.md](scripts/local/README.md)**. This approach uses DuckDB to query Parquet files directly, eliminating BigQuery costs and avoiding the 6-hour query timeout limit. Significant local storage is needed, however.
+
+### BigQuery Execution (Original)
+
+To run the low-activity heuristic, use:
 
 ```shell
 python -m scripts.dagster.simple_detector_bigquery

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,19 +1,24 @@
+import os
+
 import yaml
 
 from scripts.copycatch.iterative import CopyCatchParams
 
 
-with open("secrets.yaml", "r") as f:
-    SECRETS = yaml.safe_load(f)
+# Secrets (optional - not needed for local-only execution)
+if os.path.exists("secrets.yaml"):
+    with open("secrets.yaml", "r") as f:
+        SECRETS = yaml.safe_load(f) or {}
+else:
+    SECRETS = {}
 
-# Secrets
-MONGO_URL: str = SECRETS["mongo_url"]
-GITHUB_TOKENS: list[str] = [x["token"] for x in SECRETS["github_tokens"]]
-BIGQUERY_PROJECT: str = SECRETS["bigquery_project"]
-BIGQUERY_DATASET: str = SECRETS["bigquery_dataset"]
-GOOGLE_CLOUD_BUCKET: str = SECRETS["google_cloud_bucket"]
-NPM_FOLLOWER_POSTGRES: str = SECRETS["npm_follower_postgres"]
-VIRUS_TOTAL_API_KEY: str = SECRETS["virus_total_api_key"]
+MONGO_URL: str = SECRETS.get("mongo_url", "")
+GITHUB_TOKENS: list[str] = [x["token"] for x in SECRETS.get("github_tokens", [])]
+BIGQUERY_PROJECT: str = SECRETS.get("bigquery_project", "")
+BIGQUERY_DATASET: str = SECRETS.get("bigquery_dataset", "")
+GOOGLE_CLOUD_BUCKET: str = SECRETS.get("google_cloud_bucket", "")
+NPM_FOLLOWER_POSTGRES: str = SECRETS.get("npm_follower_postgres", "")
+VIRUS_TOTAL_API_KEY: str = SECRETS.get("virus_total_api_key", "")
 
 # Parameters for running experiments
 START_DATE: str = "190701"
@@ -50,6 +55,9 @@ COPYCATCH_DATE_CHUNKS = [
     ("240101", "240701"),
     ("240401", "241001"),
     ("240701", "250101"),
-    #("241001", "250401"),
-    #("250101", "250701"),
+    ("241001", "250401"),
+    ("250101", "250701"),
+    ("250401", "251001"),
+    ("250701", "260101"),
+    ("251001", "260401"),
 ]

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -24,7 +24,8 @@ def get_repo_id(repo: str) -> Optional[str]:
         )
         return result
     except Exception as ex:
-        logging.error(f"Error fetching repo {repo}: {ex}")
+        # Debug level - missing/deleted repos are expected in fake star detection
+        logging.debug(f"Repo not found: {repo} ({ex})")
         return None
 
 
@@ -33,7 +34,8 @@ def get_repo_n_stars_latest(repo: str) -> Optional[int]:
     try:
         return strudel.repo_info(repo)["stargazers_count"]
     except Exception as ex:
-        logging.error(f"Error fetching repo {repo}: {ex}")
+        # Debug level - missing/deleted repos are expected in fake star detection
+        logging.debug(f"Repo not found: {repo} ({ex})")
         return None
 
 
@@ -42,5 +44,5 @@ def get_user_info(user: str) -> dict:
     try:
         return strudel.user_info(user)
     except Exception as ex:
-        logging.error(f"Error fetching user {user}: {ex}")
+        logging.debug(f"User not found: {user} ({ex})")
         return {"error": str(ex)}

--- a/scripts/local/README.md
+++ b/scripts/local/README.md
@@ -1,0 +1,370 @@
+# Local Execution
+
+This module provides a local alternative to the BigQuery-based detection pipeline. It uses [DuckDB](https://duckdb.org/) to query Parquet files directly, eliminating the need for Google Cloud services.
+
+## Quick Start
+
+The fastest way to run the detection pipeline locally:
+
+```bash
+# Run detection on new data since last run (handles everything automatically)
+./scripts/local/example_run.sh new
+
+# Or choose a specific mode:
+./scripts/local/example_run.sh quick     # 1 week test (~11 GB total)
+./scripts/local/example_run.sh month     # 1 month validation (~45 GB total)
+./scripts/local/example_run.sh year      # 1 year production (~300 GB total)
+./scripts/local/example_run.sh research  # Replicate original paper (~700 GB total)
+./scripts/local/example_run.sh full      # All data to today (~750+ GB total)
+```
+
+The script automatically:
+- Creates a Python virtual environment
+- Installs dependencies
+- Downloads and converts GitHub Archive data to Parquet
+- Runs the low-activity detector
+- Runs the CopyCatch/lockstep detector (except in `quick` mode)
+- Cleans up temp files
+
+## Motivation
+
+The original BigQuery approach has limitations:
+- **Cost**: ~$6.25/TB, requiring ~$125-375+ per full execution
+- **Time limits**: BigQuery has a 6-hour query timeout that large datasets can exceed
+- **Dependencies**: Requires Google Cloud account, credentials, and billing
+
+Local execution trades cloud costs for disk space and compute time, allowing the project to be more reproducible. 
+
+## Requirements
+
+- **Python 3.12+**
+- **Disk space**: ~6 TB for full GitHub Archive (2011-present), or less for partial ranges
+- **Temp space**: 200-500 GB for DuckDB spill files during large queries (see below)
+- **RAM**: 16+ GB recommended (DuckDB spills to disk for larger-than-memory queries)
+- **No cloud credentials required**
+
+### Temp Space for Large Queries
+
+DuckDB requires significant temporary disk space for aggregation queries on large datasets. Even with query optimizations, expect:
+
+| Mode | Data Size | Temp Space Needed |
+|------|-----------|-------------------|
+| quick | ~1 GB | ~10 GB |
+| month | ~5 GB | ~40 GB |
+| year | ~47 GB | ~200-300 GB |
+| research/full | ~200+ GB | ~500+ GB |
+
+If your primary disk lacks space, symlink `data/_duckdb_temp` to external storage:
+
+```bash
+# Example: Use an external SSD/M.2 drive (faster than NAS)
+mkdir -p /Volumes/MyExternalDrive/duckdb_temp
+rm -rf data/_duckdb_temp
+ln -sf /Volumes/MyExternalDrive/duckdb_temp data/_duckdb_temp
+
+# Or use NAS if speed is less critical
+ln -sf /Volumes/nas/duckdb_temp data/_duckdb_temp
+```
+
+An external M.2/SSD drive is recommended over NAS for temp storage due to the random I/O patterns of database spill files.
+
+### GitHub API Enrichment (Optional)
+
+To match the original paper's output, you can enable GitHub API enrichment which adds:
+- `repo_id`: GitHub's GraphQL node ID for each repository
+- `n_stars_latest`: Current star count (to compare against detected fake stars)
+
+**Setup:**
+
+1. Create a GitHub Personal Access Token at https://github.com/settings/tokens
+   - Select scope: `public_repo` (read-only access)
+   - Copy the token (starts with `ghp_`)
+
+2. Create `secrets.yaml` in the project root:
+   ```yaml
+   github_tokens:
+     - token: ghp_your_token_here
+     # Add more tokens for rate limit rotation (5000 req/hr each)
+     # - token: ghp_another_token
+   ```
+
+3. Enable enrichment when running:
+   ```bash
+   ENRICH_GITHUB=true ./scripts/local/example_run.sh year
+   ```
+
+## Data Flow
+
+```
+GitHub Archive (gharchive.org)
+    ↓ download hourly .json.gz files
+Parquet files with Zstd compression
+    /data/gharchive/year=YYYY/month=MM/day=DD/HH.parquet
+    ↓ DuckDB queries with partition pruning
+Detection results
+    /data/_checkpoints/*.parquet (intermediate)
+    /data/{YYMMDD}/*.csv (final output)
+```
+
+## Setup
+
+### Local Dependencies
+
+The local execution module has its own minimal requirements file at `scripts/local/requirements.txt`. This avoids installing heavy dependencies (Dagster, Google Cloud libraries, etc.) that are only needed for the BigQuery pipeline.
+
+**Option 1: Using the example script (recommended)**
+
+The `example_run.sh` script automatically creates a virtual environment and installs dependencies:
+
+```bash
+./scripts/local/example_run.sh quick
+```
+
+**Option 2: Manual installation**
+
+```bash
+# Create and activate a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install local-only dependencies (minimal)
+pip install -r scripts/local/requirements.txt
+```
+
+The local requirements include:
+- `pandas`, `pyyaml`, `tqdm`, `requests` - Core utilities
+- `duckdb`, `pyarrow` - Local query engine and Parquet support
+- `pymongo` - MongoDB export (optional, fails gracefully)
+- `strudel.scraper` - GitHub API enrichment (optional, fails gracefully)
+
+### Optional: secrets.yaml
+
+Create `secrets.yaml` in the project root (can be empty if only using local execution):
+
+```yaml
+# Empty file is fine for local-only execution
+```
+
+### Ingest GitHub Archive Data
+
+```bash
+# Backfill a date range (downloads and converts to Parquet)
+python -m scripts.local.ingest.pipeline --backfill 2025-01-01 2025-01-18
+
+# Or incremental update (fetches recent missing hours)
+python -m scripts.local.ingest.pipeline --incremental
+```
+
+Data is stored in `data/gharchive/` by default (~50 MB/hour compressed).
+
+## Running the Detectors
+
+### Low-Activity Heuristic
+
+Identifies accounts with minimal GitHub activity (single-day activity, ≤2 actions):
+
+```bash
+python -m scripts.local.simple_detector \
+    --start-date 250101 \
+    --end-date 260118 \
+    --data-path data/gharchive \
+    --skip-mongodb
+```
+
+Output: `data/{end_date}/fake_stars_low_activity_repos.csv`
+
+### Lockstep Heuristic (CopyCatch)
+
+Detects coordinated starring behavior using clustering:
+
+```bash
+# Run the detection
+python -m scripts.local.copycatch --run \
+    --data-path data/gharchive \
+    --skip-mongodb
+
+# Export results after completion
+python -m scripts.local.copycatch --export \
+    --skip-mongodb
+```
+
+Output: `data/{end_date}/fake_stars_clustered_repos.csv`
+
+## Configuration
+
+### DuckDB Settings
+
+Environment variables (or edit `scripts/local/__init__.py`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DUCKDB_MEMORY_LIMIT` | `16GB` | Max RAM for DuckDB |
+| `DUCKDB_TEMP_DIRECTORY` | auto | Spill-to-disk location |
+| `DUCKDB_THREADS` | `4` | Parallel threads |
+
+For large datasets, ensure temp directory has sufficient space (can exceed 500 GB for full scans).
+
+### Date Chunks
+
+CopyCatch processes data in 6-month overlapping chunks defined in `scripts/__init__.py`. Add new chunks as data becomes available:
+
+```python
+COPYCATCH_DATE_CHUNKS = [
+    # ... existing chunks ...
+    ("250101", "250701"),
+    ("250401", "251001"),
+]
+```
+
+## Storage Location
+
+For large datasets, you may want to store data on external/network storage:
+
+```bash
+# Symlink to external storage
+ln -sf /path/to/external/storage/gharchive data/gharchive
+```
+
+## Performance Notes
+
+- **First run**: Expect several hours for the low-activity heuristic on a full year of data
+- **CopyCatch**: May take days for full historical analysis (processes each chunk iteratively)
+- **Disk I/O**: SSD recommended; NAS/SMB works but is slower
+- **Temp I/O**: External M.2/SSD strongly recommended for `data/_duckdb_temp` - random I/O patterns make NAS significantly slower
+- **Memory**: DuckDB efficiently spills to disk, but more RAM = faster queries
+
+## Comparison with BigQuery
+
+| Aspect | BigQuery | Local |
+|--------|----------|-------|
+| Cost | $125-375+ per run | Electricity only |
+| Speed | Minutes (parallel) | Hours (sequential) |
+| Data freshness | Real-time | Manual ingestion |
+| Setup | Cloud credentials | Disk space |
+| Query limits | 6-hour timeout | None |
+
+## Custom Queries
+
+You can run ad-hoc queries against the local Parquet files using DuckDB's CLI or Python.
+
+### DuckDB CLI
+
+```bash
+# Install DuckDB CLI
+brew install duckdb          # macOS
+# apt install duckdb         # Debian/Ubuntu
+# choco install duckdb       # Windows
+# Or download from: https://duckdb.org/docs/installation/
+
+# Start interactive session (from project root)
+cd /path/to/StarScout
+duckdb
+```
+
+Once in the DuckDB shell, you can run SQL queries directly:
+
+```sql
+-- Find most starred repos in January 2025
+SELECT
+    repo_name,
+    COUNT(*) as star_count
+FROM read_parquet('data/gharchive/**/*.parquet', hive_partitioning=true)
+WHERE is_star = true
+  AND created_at >= '2025-01-01'
+  AND created_at < '2025-02-01'
+GROUP BY repo_name
+ORDER BY star_count DESC
+LIMIT 20;
+
+-- Find users who starred the most repos
+SELECT
+    actor_login,
+    COUNT(DISTINCT repo_name) as repos_starred
+FROM read_parquet('data/gharchive/**/*.parquet', hive_partitioning=true)
+WHERE is_star = true
+GROUP BY actor_login
+ORDER BY repos_starred DESC
+LIMIT 20;
+
+-- Export results to CSV
+COPY (
+    SELECT repo_name, COUNT(*) as stars
+    FROM read_parquet('data/gharchive/**/*.parquet', hive_partitioning=true)
+    WHERE is_star = true
+    GROUP BY repo_name
+    HAVING COUNT(*) >= 100
+) TO 'my_results.csv' (HEADER, DELIMITER ',');
+```
+
+One-liner queries from the command line:
+
+```bash
+# Quick query without entering interactive mode
+duckdb -c "SELECT COUNT(*) FROM read_parquet('data/gharchive/**/*.parquet', hive_partitioning=true) WHERE is_star"
+
+# Output to CSV directly
+duckdb -csv -c "SELECT repo_name, COUNT(*) as stars FROM read_parquet('data/gharchive/**/*.parquet', hive_partitioning=true) WHERE is_star GROUP BY 1 ORDER BY 2 DESC LIMIT 100" > top_repos.csv
+
+# For large queries, increase memory and set temp directory
+duckdb -c "SET memory_limit='8GB'; SET temp_directory='data/_duckdb_temp'; SELECT ..."
+```
+
+### Python
+
+```python
+import duckdb
+
+con = duckdb.connect()
+con.execute("SET memory_limit = '8GB'")
+con.execute("SET temp_directory = 'data/_duckdb_temp'")
+
+# Find most starred repos in January 2025
+df = con.execute("""
+    SELECT
+        repo_name,
+        COUNT(*) as star_count,
+        COUNT(DISTINCT actor_login) as unique_stargazers
+    FROM read_parquet('data/gharchive/**/*.parquet', hive_partitioning=true)
+    WHERE is_star = true
+      AND created_at >= '2025-01-01'
+      AND created_at < '2025-02-01'
+    GROUP BY repo_name
+    ORDER BY star_count DESC
+    LIMIT 100
+""").fetchdf()
+
+print(df)
+```
+
+### Parquet Schema
+
+The ingested Parquet files have this schema:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | BIGINT | GitHub event ID |
+| `type` | VARCHAR | Event type (WatchEvent, PushEvent, etc.) |
+| `created_at` | TIMESTAMP | Event timestamp |
+| `actor_id` | BIGINT | User's GitHub ID |
+| `actor_login` | VARCHAR | Username |
+| `repo_id` | BIGINT | Repository's GitHub ID |
+| `repo_name` | VARCHAR | Repository name (owner/repo) |
+| `org_id` | BIGINT | Organization ID (nullable) |
+| `org_login` | VARCHAR | Organization name (nullable) |
+| `is_star` | BOOLEAN | True if WatchEvent with action=started |
+
+### Partition Structure
+
+Files are organized using Hive-style partitioning:
+```
+data/gharchive/
+  year=2025/
+    month=01/
+      day=15/
+        00.parquet
+        01.parquet
+        ...
+        23.parquet
+```
+
+DuckDB automatically prunes partitions when filtering on `created_at`, making date-range queries efficient.

--- a/scripts/local/__init__.py
+++ b/scripts/local/__init__.py
@@ -1,0 +1,113 @@
+"""
+Local execution layer using DuckDB.
+
+Provides a drop-in replacement for scripts/gcp.py functionality,
+reading from local Parquet files instead of BigQuery.
+"""
+
+import os
+from pathlib import Path
+
+import duckdb
+
+# Default paths
+DEFAULT_DATA_PATH = Path("data/gharchive")
+DEFAULT_CHECKPOINT_PATH = Path("data/_checkpoints")
+
+# DuckDB configuration
+# Memory limit - set higher than physical RAM, let OS handle swap if needed
+# This prevents DuckDB OOM errors on complex queries like CopyCatch reduce_centers
+DUCKDB_MEMORY_LIMIT = os.environ.get("DUCKDB_MEMORY_LIMIT", "32GB")
+
+# Temp directory for spill-to-disk
+# Default to local temp directory; override with DUCKDB_TEMP_DIRECTORY env var
+DUCKDB_TEMP_DIRECTORY = os.environ.get("DUCKDB_TEMP_DIRECTORY", "data/_duckdb_temp")
+
+# Number of threads (reduce to limit memory pressure during complex JOINs)
+DUCKDB_THREADS = int(os.environ.get("DUCKDB_THREADS", "2"))
+
+# Connection pool for reuse
+_connection: duckdb.DuckDBPyConnection | None = None
+
+
+def get_connection(
+    memory_limit: str = DUCKDB_MEMORY_LIMIT,
+    temp_directory: str = DUCKDB_TEMP_DIRECTORY,
+    threads: int = DUCKDB_THREADS,
+) -> duckdb.DuckDBPyConnection:
+    """
+    Get a configured DuckDB connection.
+
+    Uses a singleton pattern for connection reuse within a process.
+    """
+    global _connection
+
+    if _connection is None:
+        _connection = duckdb.connect()
+
+        # Configure memory
+        _connection.execute(f"SET memory_limit = '{memory_limit}'")
+
+        # Configure temp directory for large queries
+        if temp_directory:
+            _connection.execute(f"SET temp_directory = '{temp_directory}'")
+
+        # Configure threads
+        if threads > 0:
+            _connection.execute(f"SET threads = {threads}")
+
+        # Enable progress bar for long queries
+        _connection.execute("SET enable_progress_bar = true")
+
+        # Disable insertion order preservation - saves significant memory on large queries
+        _connection.execute("SET preserve_insertion_order = false")
+
+        # Allow unlimited temp directory size for large aggregations
+        _connection.execute("SET max_temp_directory_size = '2TB'")
+
+        # Optimize for lower temp disk usage
+        _connection.execute("SET force_compression = 'zstd'")  # Compress intermediate results
+        _connection.execute("SET checkpoint_threshold = '256MB'")  # More frequent checkpoints
+        _connection.execute("SET wal_autocheckpoint = '256MB'")  # Smaller WAL before checkpoint
+
+    return _connection
+
+
+def close_connection():
+    """Close the global connection."""
+    global _connection
+    if _connection is not None:
+        _connection.close()
+        _connection = None
+
+
+def new_connection(**kwargs) -> duckdb.DuckDBPyConnection:
+    """
+    Create a new independent connection.
+
+    Use this when you need isolation from the global connection,
+    e.g., for parallel query execution.
+    """
+    con = duckdb.connect()
+
+    memory_limit = kwargs.get("memory_limit", DUCKDB_MEMORY_LIMIT)
+    temp_directory = kwargs.get("temp_directory", DUCKDB_TEMP_DIRECTORY)
+    threads = kwargs.get("threads", DUCKDB_THREADS)
+
+    con.execute(f"SET memory_limit = '{memory_limit}'")
+    if temp_directory:
+        con.execute(f"SET temp_directory = '{temp_directory}'")
+    if threads > 0:
+        con.execute(f"SET threads = {threads}")
+
+    # Apply same optimizations as get_connection
+    con.execute("SET enable_progress_bar = true")
+    con.execute("SET preserve_insertion_order = false")
+    con.execute("SET max_temp_directory_size = '2TB'")
+
+    # Optimize for lower temp disk usage
+    con.execute("SET force_compression = 'zstd'")
+    con.execute("SET checkpoint_threshold = '256MB'")
+    con.execute("SET wal_autocheckpoint = '256MB'")
+
+    return con

--- a/scripts/local/copycatch.py
+++ b/scripts/local/copycatch.py
@@ -1,0 +1,503 @@
+"""
+CopyCatch lockstep fake star detector using local DuckDB execution.
+
+This is the local version of bigquery.py that reads from Parquet files
+instead of BigQuery.
+
+Usage:
+    python -m scripts.local.copycatch --run
+    python -m scripts.local.copycatch --run-one 240701-250101
+    python -m scripts.local.copycatch --export
+"""
+
+import argparse
+import logging
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import pandas as pd
+import pyarrow.parquet as pq
+import pymongo
+
+from scripts import (
+    END_DATE,
+    MONGO_URL,
+    MIN_STARS_COPYCATCH_SEED,
+    COPYCATCH_NUM_ITERATIONS,
+    COPYCATCH_PARAMS,
+    COPYCATCH_DATE_CHUNKS,
+)
+from . import DEFAULT_DATA_PATH, DEFAULT_CHECKPOINT_PATH
+from .queries import (
+    query_to_df,
+    query_to_parquet,
+    yymmdd_to_date,
+)
+
+
+def get_chunk_checkpoint_dir(checkpoint_path: Path, start_date: str, end_date: str) -> Path:
+    """Get the checkpoint directory for a date chunk."""
+    return checkpoint_path / "copycatch" / f"{start_date}_{end_date}"
+
+
+def get_stargazer_data(
+    start_date: str,
+    end_date: str,
+    data_path: Path,
+    checkpoint_path: Path,
+) -> Path:
+    """
+    Extract all star events for a date chunk.
+
+    Returns path to the stargazers checkpoint file.
+    """
+    chunk_dir = get_chunk_checkpoint_dir(checkpoint_path, start_date, end_date)
+    chunk_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = chunk_dir / "stargazers.parquet"
+    if output_path.exists():
+        logging.info("Stargazers checkpoint exists: %s", output_path)
+        return output_path
+
+    logging.info("Extracting stargazer data (%s to %s)", start_date, end_date)
+
+    sql = Path("scripts/local/sql/copycatch/stg_stargazers_all.sql").read_text()
+    start_dt = yymmdd_to_date(start_date)
+    end_dt = yymmdd_to_date(end_date)
+
+    query_to_parquet(
+        sql,
+        output_path,
+        params={
+            "start_date": start_dt.strftime("%Y-%m-%d"),
+            "end_date": end_dt.strftime("%Y-%m-%d"),
+        },
+        data_path=data_path,
+    )
+
+    logging.info("Created stargazers checkpoint: %s", output_path)
+    return output_path
+
+
+def get_initial_centers(
+    start_date: str,
+    end_date: str,
+    checkpoint_path: Path,
+) -> Path:
+    """
+    Initialize cluster centers from repositories with enough stars.
+
+    Returns path to the centers checkpoint file.
+    """
+    chunk_dir = get_chunk_checkpoint_dir(checkpoint_path, start_date, end_date)
+    stargazers_path = chunk_dir / "stargazers.parquet"
+    output_path = chunk_dir / "centers.parquet"
+
+    if not stargazers_path.exists():
+        raise FileNotFoundError(f"Stargazers checkpoint not found: {stargazers_path}")
+
+    logging.info("Initializing cluster centers (%s to %s)", start_date, end_date)
+
+    sql = Path("scripts/local/sql/copycatch/stg_initial_centers.sql").read_text()
+
+    query_to_parquet(
+        sql,
+        output_path,
+        params={
+            "stargazers_checkpoint": str(stargazers_path),
+            "min_stars_copycatch_seed": MIN_STARS_COPYCATCH_SEED,
+        },
+    )
+
+    n_centers = pq.read_metadata(output_path).num_rows
+    logging.info("Created %d initial centers: %s", n_centers, output_path)
+    return output_path
+
+
+def map_users(
+    start_date: str,
+    end_date: str,
+    checkpoint_path: Path,
+) -> tuple[Path, int]:
+    """
+    Map users to clusters based on temporal proximity.
+
+    Returns (path to users checkpoint, number of user-cluster pairs).
+    """
+    chunk_dir = get_chunk_checkpoint_dir(checkpoint_path, start_date, end_date)
+    centers_path = chunk_dir / "centers.parquet"
+    stargazers_path = chunk_dir / "stargazers.parquet"
+    output_path = chunk_dir / "users.parquet"
+
+    sql = Path("scripts/local/sql/copycatch/map_users.sql").read_text()
+
+    query_to_parquet(
+        sql,
+        output_path,
+        params={
+            "centers_checkpoint": str(centers_path),
+            "stargazers_checkpoint": str(stargazers_path),
+            "delta_t": COPYCATCH_PARAMS.delta_t,
+            "rho": COPYCATCH_PARAMS.rho,
+        },
+    )
+
+    n_users = pq.read_metadata(output_path).num_rows
+    logging.info("Mapped %d (repo, actor) pairs", n_users)
+    return output_path, n_users
+
+
+def reduce_centers(
+    start_date: str,
+    end_date: str,
+    checkpoint_path: Path,
+) -> tuple[Path, int]:
+    """
+    Update cluster centers based on user assignments.
+
+    Returns (path to updated centers, number of centers).
+    """
+    chunk_dir = get_chunk_checkpoint_dir(checkpoint_path, start_date, end_date)
+    centers_path = chunk_dir / "centers.parquet"
+    users_path = chunk_dir / "users.parquet"
+    stargazers_path = chunk_dir / "stargazers.parquet"
+
+    sql = Path("scripts/local/sql/copycatch/reduce_centers.sql").read_text()
+
+    # Write to temp file, then replace
+    temp_path = chunk_dir / "centers_new.parquet"
+
+    query_to_parquet(
+        sql,
+        temp_path,
+        params={
+            "centers_checkpoint": str(centers_path),
+            "users_checkpoint": str(users_path),
+            "stargazers_checkpoint": str(stargazers_path),
+            "delta_t": COPYCATCH_PARAMS.delta_t,
+            "relaxed_m": 20 * COPYCATCH_PARAMS.m,
+            "m": COPYCATCH_PARAMS.m,
+        },
+    )
+
+    # Replace old centers with new
+    temp_path.replace(centers_path)
+
+    n_centers = pq.read_metadata(centers_path).num_rows
+    logging.info("Updated to %d centers", n_centers)
+    return centers_path, n_centers
+
+
+def run_chunk(
+    start_date: str,
+    end_date: str,
+    data_path: Path,
+    checkpoint_path: Path,
+    max_iterations: int = COPYCATCH_NUM_ITERATIONS,
+) -> None:
+    """
+    Run CopyCatch algorithm on a single date chunk.
+
+    Unlike BigQuery, we can run until true convergence (no 6-hour limit).
+    """
+    logging.info("Processing chunk %s to %s", start_date, end_date)
+
+    chunk_dir = get_chunk_checkpoint_dir(checkpoint_path, start_date, end_date)
+    done_marker = chunk_dir / ".done"
+
+    if done_marker.exists():
+        logging.info("Chunk already completed: %s", chunk_dir)
+        return
+
+    # Step 1: Extract stargazer data
+    get_stargazer_data(start_date, end_date, data_path, checkpoint_path)
+
+    # Step 2: Initialize centers
+    get_initial_centers(start_date, end_date, checkpoint_path)
+
+    # Step 3: Iterative clustering
+    n_prev_users = -1
+    for i in range(max_iterations):
+        users_path, n_users = map_users(start_date, end_date, checkpoint_path)
+
+        if n_users == n_prev_users:
+            logging.info("Converged after %d iterations (no new users)", i + 1)
+            break
+        n_prev_users = n_users
+
+        centers_path, n_centers = reduce_centers(start_date, end_date, checkpoint_path)
+        logging.info("Iteration %d: %d users, %d clusters", i + 1, n_users, n_centers)
+
+    # Mark as complete
+    done_marker.touch()
+    logging.info("Finished chunk %s_%s", start_date, end_date)
+
+
+def agg_results(
+    start_date: str,
+    end_date: str,
+    checkpoint_path: Path,
+) -> Path:
+    """
+    Aggregate final CopyCatch results for a chunk.
+
+    Returns path to clusters checkpoint.
+    """
+    chunk_dir = get_chunk_checkpoint_dir(checkpoint_path, start_date, end_date)
+    centers_path = chunk_dir / "centers.parquet"
+    users_path = chunk_dir / "users.parquet"
+    output_path = chunk_dir / "clusters.parquet"
+
+    if output_path.exists():
+        logging.info("Clusters checkpoint exists: %s", output_path)
+        return output_path
+
+    sql = Path("scripts/local/sql/copycatch/agg_results.sql").read_text()
+
+    query_to_parquet(
+        sql,
+        output_path,
+        params={
+            "centers_checkpoint": str(centers_path),
+            "users_checkpoint": str(users_path),
+            "n": COPYCATCH_PARAMS.n,
+            "m": COPYCATCH_PARAMS.m,
+        },
+    )
+
+    n_clusters = pq.read_metadata(output_path).num_rows
+    logging.info("Aggregated %d clusters: %s", n_clusters, output_path)
+    return output_path
+
+
+def summarize_all_chunks(
+    checkpoint_path: Path,
+    date_chunks: list[tuple[str, str]],
+) -> dict[str, set[str]]:
+    """
+    Summarize results from all chunks.
+
+    Returns dict mapping repo_name -> set of fake actor logins.
+    """
+    repo_to_fakes = defaultdict(set)
+
+    for start_date, end_date in date_chunks:
+        chunk_dir = get_chunk_checkpoint_dir(checkpoint_path, start_date, end_date)
+        clusters_path = chunk_dir / "clusters.parquet"
+        stargazers_path = chunk_dir / "stargazers.parquet"
+
+        if not clusters_path.exists():
+            logging.warning("Clusters not found for %s_%s, skipping", start_date, end_date)
+            continue
+
+        # Load stargazers mapping
+        stargazers_df = pd.read_parquet(stargazers_path)
+        repo_user_to_time = {
+            (row["repo_name"], row["actor"]): row["starred_at"]
+            for _, row in stargazers_df.iterrows()
+        }
+        logging.info("Loaded %d stargazers for %s_%s", len(repo_user_to_time), start_date, end_date)
+
+        # Load clusters
+        clusters_df = pd.read_parquet(clusters_path)
+
+        for _, row in clusters_df.iterrows():
+            cluster_repos = row["cluster"]
+            actors = row["actors"]
+
+            if len(cluster_repos) < COPYCATCH_PARAMS.m * COPYCATCH_PARAMS.rho:
+                continue
+
+            # Validate cluster
+            valid_repos = 0
+            for repo in cluster_repos:
+                star_count = sum(
+                    1 for actor in actors if (repo, actor) in repo_user_to_time
+                )
+                if star_count >= COPYCATCH_PARAMS.n:
+                    valid_repos += 1
+
+            if valid_repos < COPYCATCH_PARAMS.m * COPYCATCH_PARAMS.rho:
+                continue
+
+            # Add to results
+            for repo in cluster_repos:
+                star_count = sum(
+                    1 for actor in actors if (repo, actor) in repo_user_to_time
+                )
+                if star_count >= COPYCATCH_PARAMS.n:
+                    repo_to_fakes[repo].update(actors)
+
+    logging.info(
+        "Total: %d repos with fake stars, %d unique fake actors",
+        len(repo_to_fakes),
+        len(set().union(*repo_to_fakes.values())) if repo_to_fakes else 0,
+    )
+
+    return repo_to_fakes
+
+
+def export_csv(
+    repo_to_fakes: dict[str, set[str]],
+    output_dir: Path,
+) -> Path:
+    """Export results to CSV file."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for repo, fakes in repo_to_fakes.items():
+        results.append({
+            "repo_name": repo,
+            "n_stars_clustered": len(fakes),
+        })
+
+    df = pd.DataFrame(results)
+    df.sort_values(by="n_stars_clustered", ascending=False, inplace=True)
+
+    output_path = output_dir / "fake_stars_clustered_repos.csv"
+    df.to_csv(output_path, index=False)
+    logging.info("Saved: %s", output_path)
+
+    return output_path
+
+
+def export_mongodb(
+    repo_to_fakes: dict[str, set[str]],
+    checkpoint_path: Path,
+    date_chunks: list[tuple[str, str]],
+    mongo_url: str,
+) -> int:
+    """Export results to MongoDB."""
+    client = pymongo.MongoClient(mongo_url)
+    collection = client.fake_stars.clustered_stars
+    collection.drop()
+    collection.create_index(["repo", "actor", "starred_at"], unique=True)
+
+    total_inserted = 0
+
+    for start_date, end_date in date_chunks:
+        chunk_dir = get_chunk_checkpoint_dir(checkpoint_path, start_date, end_date)
+        stargazers_path = chunk_dir / "stargazers.parquet"
+
+        if not stargazers_path.exists():
+            continue
+
+        stargazers_df = pd.read_parquet(stargazers_path)
+
+        records = []
+        for _, row in stargazers_df.iterrows():
+            repo = row["repo_name"]
+            actor = row["actor"]
+
+            if repo not in repo_to_fakes:
+                continue
+
+            is_clustered = actor in repo_to_fakes[repo]
+            records.append({
+                "repo": repo,
+                "actor": actor,
+                "starred_at": str(row["starred_at"]),
+                "clustered": is_clustered,
+            })
+
+            if len(records) >= 10000:
+                collection.insert_many(records)
+                total_inserted += len(records)
+                records.clear()
+
+        if records:
+            collection.insert_many(records)
+            total_inserted += len(records)
+
+    client.close()
+    logging.info("Inserted %d records to MongoDB", total_inserted)
+    return total_inserted
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run CopyCatch lockstep detection locally"
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run CopyCatch on all date chunks",
+    )
+    parser.add_argument(
+        "--run-one",
+        type=str,
+        default=None,
+        help="Run CopyCatch on one date range (format: YYMMDD-YYMMDD)",
+    )
+    parser.add_argument(
+        "--export",
+        action="store_true",
+        help="Aggregate and export results",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to Parquet data (default: {DEFAULT_DATA_PATH})",
+    )
+    parser.add_argument(
+        "--checkpoint-path",
+        type=Path,
+        default=DEFAULT_CHECKPOINT_PATH,
+        help=f"Path for checkpoints (default: {DEFAULT_CHECKPOINT_PATH})",
+    )
+    parser.add_argument(
+        "--skip-mongodb",
+        action="store_true",
+        help="Skip MongoDB export",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)s (PID %(process)d) [%(levelname)s] %(filename)s:%(lineno)d %(message)s",
+        level=logging.INFO,
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+    if args.run:
+        for start_date, end_date in COPYCATCH_DATE_CHUNKS:
+            run_chunk(start_date, end_date, args.data_path, args.checkpoint_path)
+
+    if args.run_one:
+        start_date, end_date = args.run_one.split("-")
+        run_chunk(start_date, end_date, args.data_path, args.checkpoint_path)
+
+    if args.export:
+        # Aggregate results from all chunks
+        for start_date, end_date in COPYCATCH_DATE_CHUNKS:
+            chunk_dir = get_chunk_checkpoint_dir(args.checkpoint_path, start_date, end_date)
+            if (chunk_dir / ".done").exists():
+                agg_results(start_date, end_date, args.checkpoint_path)
+
+        # Summarize all
+        repo_to_fakes = summarize_all_chunks(args.checkpoint_path, COPYCATCH_DATE_CHUNKS)
+
+        # Export to CSV
+        output_dir = Path(f"data/{END_DATE}")
+        export_csv(repo_to_fakes, output_dir)
+
+        # Export to MongoDB
+        if not args.skip_mongodb:
+            try:
+                export_mongodb(
+                    repo_to_fakes,
+                    args.checkpoint_path,
+                    COPYCATCH_DATE_CHUNKS,
+                    MONGO_URL,
+                )
+            except Exception as e:
+                logging.warning("MongoDB export failed: %s", e)
+
+    logging.info("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local/example_run.sh
+++ b/scripts/local/example_run.sh
@@ -1,0 +1,367 @@
+#!/bin/bash
+#
+# StarScout Local Execution Example
+#
+# This script demonstrates how to run StarScout entirely on local storage
+# without requiring NAS, BigQuery, or GCS.
+#
+# The methodology mirrors the original ICSE '26 paper:
+#   1. Low-activity heuristic: Identifies accounts with minimal GitHub activity
+#   2. CopyCatch/Lockstep heuristic: Detects coordinated starring in time windows
+#
+# Original research used July 2019 - January 2025 (5.5 years, ~200 GB).
+# This script provides smaller date ranges for testing and validation.
+#
+# Prerequisites:
+#   - Python 3.12 (dependencies auto-installed from scripts/local/requirements.txt)
+#   - Disk space varies by mode (see below)
+#   - Temp space for DuckDB: 10-500 GB depending on mode (see Temp Space below)
+#
+# Temp Space:
+#   DuckDB spills intermediate results to disk during large aggregations.
+#   If your primary disk lacks space, symlink data/_duckdb_temp to external storage:
+#
+#     ln -sf /Volumes/MyExternalDrive/duckdb_temp data/_duckdb_temp
+#
+#   An external M.2/SSD is faster than NAS for this purpose due to random I/O.
+#
+# Usage:
+#   ./scripts/local/example_run.sh [quick|month|year|research|full]
+#
+#   quick    - 1 week of data (~1 GB, ~10 GB temp), good for testing
+#   month    - 1 month of data (~5 GB, ~40 GB temp), good for validation
+#   year     - 1 year of data (~47 GB, ~250 GB temp), Jan 2025 - Jan 2026
+#   new      - New data since last run (auto-detects from data/YYMMDD/)
+#   research - 5.5 years (~200 GB, ~500 GB temp), replicates original paper
+#   full     - All data from Jul 2019 to today (~250+ GB, ~500+ GB temp)
+#
+
+set -e
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+# Data paths (override with environment variables if needed)
+DATA_PATH="${STARSCOUT_DATA_PATH:-data/gharchive}"
+CHECKPOINT_PATH="${STARSCOUT_CHECKPOINT_PATH:-data/_checkpoints}"
+TEMP_PATH="${STARSCOUT_TEMP_PATH:-data/_duckdb_temp}"
+
+# DuckDB settings - adjust based on your system
+# Memory: Set higher than physical RAM - macOS will swap if needed
+# This prevents DuckDB OOM errors on complex queries
+export DUCKDB_MEMORY_LIMIT="${DUCKDB_MEMORY_LIMIT:-32GB}"
+export DUCKDB_TEMP_DIRECTORY="$TEMP_PATH"
+export DUCKDB_THREADS="${DUCKDB_THREADS:-2}"
+
+# Run mode
+MODE="${1:-quick}"
+
+# Date ranges for each mode
+case "$MODE" in
+    quick)
+        # 1 week - good for testing (~1 GB)
+        BACKFILL_START="2025-01-08"
+        BACKFILL_END="2025-01-15"
+        DETECT_START="250108"
+        DETECT_END="250115"
+        DISK_REQUIRED=5
+        ;;
+    month)
+        # 1 month - good for validation (~5 GB)
+        BACKFILL_START="2025-01-01"
+        BACKFILL_END="2025-02-01"
+        DETECT_START="250101"
+        DETECT_END="250201"
+        DISK_REQUIRED=15
+        ;;
+    year)
+        # 1 year - production run (~47 GB)
+        BACKFILL_START="2025-01-01"
+        BACKFILL_END="2026-01-01"
+        DETECT_START="250101"
+        DETECT_END="260101"
+        DISK_REQUIRED=80
+        ;;
+    new)
+        # New data since last run (auto-detects from existing output directories)
+        # Looks for data/YYMMDD/ directories with actual CSV results
+        LAST_RUN=""
+        for dir in $(ls -d data/[0-9][0-9][0-9][0-9][0-9][0-9]/ 2>/dev/null | sort -r); do
+            if ls "$dir"/*.csv >/dev/null 2>&1; then
+                LAST_RUN=$(echo "$dir" | grep -oE '[0-9]{6}')
+                break
+            fi
+        done
+        if [ -z "$LAST_RUN" ]; then
+            # No previous runs found, fall back to END_DATE from config
+            LAST_RUN=$(python3 -c "from scripts import END_DATE; print(END_DATE)" 2>/dev/null || echo "250101")
+            echo "No previous runs found, starting from config END_DATE: $LAST_RUN"
+        else
+            echo "Found last successful run: $LAST_RUN"
+        fi
+
+        # Find the last available data date (not today, which may not have data yet)
+        LAST_DATA=$(ls -d data/gharchive/year=*/month=*/day=*/ 2>/dev/null | sort -r | head -1 | grep -oE 'year=([0-9]+)/month=([0-9]+)/day=([0-9]+)' | sed 's/year=\([0-9]\{4\}\)\/month=\([0-9]\{2\}\)\/day=\([0-9]\{2\}\)/\1-\2-\3/' || echo "")
+        if [ -n "$LAST_DATA" ]; then
+            # Convert YYYY-MM-DD to YYMMDD
+            DETECT_END="${LAST_DATA:2:2}${LAST_DATA:5:2}${LAST_DATA:8:2}"
+            BACKFILL_END="$LAST_DATA"
+            echo "Latest data available: $LAST_DATA"
+        else
+            BACKFILL_END=$(date +%Y-%m-%d)
+            DETECT_END=$(date +%y%m%d)
+        fi
+
+        # Convert YYMMDD to YYYY-MM-DD for backfill
+        BACKFILL_START="20${LAST_RUN:0:2}-${LAST_RUN:2:2}-${LAST_RUN:4:2}"
+        DETECT_START="$LAST_RUN"
+        DISK_REQUIRED=60
+
+        # Check if there's actually new data to process
+        if [ "$DETECT_START" = "$DETECT_END" ]; then
+            echo ""
+            echo "ERROR: No new data to process."
+            echo "  Last successful run: $DETECT_START"
+            echo "  Latest available data: $DETECT_END"
+            echo ""
+            echo "Either:"
+            echo "  1. Run ingestion to get newer data: $PYTHON -m scripts.local.ingest.pipeline --incremental"
+            echo "  2. Use a different mode: ./scripts/local/example_run.sh year"
+            exit 0
+        fi
+        ;;
+    research)
+        # Original paper date range: July 2019 - January 2025 (~200 GB)
+        # This replicates the methodology from the ICSE '26 paper
+        BACKFILL_START="2019-07-01"
+        BACKFILL_END="2025-01-01"
+        DETECT_START="190701"
+        DETECT_END="250101"
+        DISK_REQUIRED=250
+        ;;
+    full)
+        # Full dataset: July 2019 to current day
+        # Extends the original research to include all available data
+        BACKFILL_START="2019-07-01"
+        BACKFILL_END=$(date +%Y-%m-%d)
+        DETECT_START="190701"
+        DETECT_END=$(date +%y%m%d)
+        # Estimate: ~37 GB/year, ~200 GB for 2019-2025, plus ~4 GB/month after
+        DISK_REQUIRED=300
+        ;;
+    *)
+        echo "Usage: $0 [quick|month|year|new|research|full]"
+        echo ""
+        echo "Modes:                        Data      Temp Space"
+        echo "  quick    - 1 week test       ~1 GB     ~10 GB"
+        echo "  month    - 1 month validate  ~5 GB     ~40 GB"
+        echo "  year     - Jan 2025-2026     ~47 GB    ~250 GB"
+        echo "  new      - Since last run    varies    varies"
+        echo "  research - Jul 2019-Jan 2025 ~200 GB   ~500 GB"
+        echo "  full     - Jul 2019-today    ~250+ GB  ~500+ GB"
+        echo ""
+        echo "The 'research' mode replicates the original ICSE '26 paper methodology."
+        echo "The 'new' mode analyzes data since your last run (incremental)."
+        echo "The 'full' mode includes all data from Jul 2019 to today."
+        exit 1
+        ;;
+esac
+
+# -----------------------------------------------------------------------------
+# Helper functions
+# -----------------------------------------------------------------------------
+
+log() {
+    echo "[$(date '+%H:%M:%S')] $*"
+}
+
+check_disk_space() {
+    local required_gb=$1
+    local available_gb=$(df -g . | awk 'NR==2 {print $4}')
+
+    if [ "$available_gb" -lt "$required_gb" ]; then
+        echo "ERROR: Insufficient disk space."
+        echo "  Required: ${required_gb} GB"
+        echo "  Available: ${available_gb} GB"
+        exit 1
+    fi
+    log "Disk space OK: ${available_gb} GB available (need ${required_gb} GB)"
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+echo "=============================================="
+echo "StarScout Local Execution"
+echo "=============================================="
+echo ""
+TEMP_REAL_PATH=$(readlink "$TEMP_PATH" 2>/dev/null || echo "$TEMP_PATH")
+TEMP_AVAIL=$(df -h "$TEMP_REAL_PATH" 2>/dev/null | awk 'NR==2 {print $4}' || echo "unknown")
+
+echo "Mode:           $MODE"
+echo "Data path:      $DATA_PATH"
+echo "Checkpoint:     $CHECKPOINT_PATH"
+echo "Temp path:      $TEMP_PATH -> $TEMP_REAL_PATH ($TEMP_AVAIL available)"
+echo "Memory limit:   $DUCKDB_MEMORY_LIMIT"
+echo "Threads:        $DUCKDB_THREADS"
+echo "Date range:     $BACKFILL_START to $BACKFILL_END"
+echo ""
+
+echo "=============================================="
+echo "Methodology Notes"
+echo "=============================================="
+echo ""
+echo "This local execution mirrors the original ICSE '26 paper methodology:"
+echo ""
+echo "  1. LOW-ACTIVITY HEURISTIC: Identifies GitHub accounts with minimal"
+echo "     activity (single-day activity, ≤2 actions, ≤1 repo, ≤1 org)."
+echo "     These accounts are likely created solely for starring."
+echo ""
+echo "  2. COPYCATCH/LOCKSTEP HEURISTIC: Detects coordinated starring by"
+echo "     finding clusters of users who star the same repos in similar"
+echo "     time windows. Uses overlapping 6-month chunks."
+echo ""
+echo "Key differences from original paper:"
+echo "  - Original used BigQuery on GitHub Archive (expensive, rate-limited)"
+echo "  - This version uses local Parquet + DuckDB (free, unlimited)"
+echo "  - GitHub API enrichment runs if secrets.yaml has tokens (silent skip otherwise)"
+echo "  - MongoDB storage is optional (skipped by default)"
+echo ""
+echo "Storage tip: DuckDB temp files can exceed 200-500 GB for large runs."
+echo "  Symlink data/_duckdb_temp to external storage if needed:"
+echo "    ln -sf /Volumes/MyExternalDrive/duckdb_temp data/_duckdb_temp"
+echo ""
+
+# Check disk space
+check_disk_space $DISK_REQUIRED
+
+# Create directories
+log "Creating directories..."
+mkdir -p "$DATA_PATH" "$CHECKPOINT_PATH" "$TEMP_PATH"
+
+# Clean up any leftover temp files from previous failed runs
+log "Cleaning up any leftover temp files..."
+rm -rf "$TEMP_PATH"/* 2>/dev/null || true
+
+# -----------------------------------------------------------------------------
+# Step 0: Setup virtual environment and install dependencies
+# -----------------------------------------------------------------------------
+
+log "Step 0: Setting up Python environment..."
+
+# Create venv if it doesn't exist
+if [ ! -d ".venv" ]; then
+    log "  Creating virtual environment (.venv)..."
+    python3 -m venv .venv
+fi
+
+# Use venv's Python directly (more reliable than source activate in scripts)
+PYTHON=".venv/bin/python3"
+PIP=".venv/bin/pip"
+
+# Install dependencies if needed (stscraper = strudel.scraper for GitHub API)
+if ! "$PYTHON" -c "import yaml, pandas, duckdb, pyarrow, tqdm, requests, stscraper" 2>/dev/null; then
+    log "  Installing dependencies from scripts/local/requirements.txt..."
+    "$PIP" install -q -r scripts/local/requirements.txt
+fi
+log "  Dependencies OK (using $($PYTHON --version))"
+
+# -----------------------------------------------------------------------------
+# Step 1: Ingest data from GitHub Archive
+# -----------------------------------------------------------------------------
+
+log "Step 1: Ingesting GitHub Archive data..."
+log "  This downloads from gharchive.org and converts to Parquet"
+log "  Range: $BACKFILL_START to $BACKFILL_END"
+echo ""
+
+"$PYTHON" -m scripts.local.ingest.pipeline \
+    --data-path "$DATA_PATH" \
+    --backfill "$BACKFILL_START" "$BACKFILL_END"
+
+# Retry any failed hours (network glitches, temporary gharchive.org issues)
+log "Retrying any failed hours..."
+"$PYTHON" -m scripts.local.ingest.pipeline --data-path "$DATA_PATH" --retry-failed
+
+echo ""
+log "Ingestion complete. Checking stats..."
+"$PYTHON" -m scripts.local.ingest.pipeline --data-path "$DATA_PATH" --stats
+
+# -----------------------------------------------------------------------------
+# Step 2: Run low-activity detector
+# -----------------------------------------------------------------------------
+
+echo ""
+log "Step 2: Running low-activity fake star detector..."
+log "  This identifies accounts with minimal GitHub activity"
+echo ""
+
+# Build detector arguments (always try GitHub enrichment - silently skips if no tokens)
+DETECTOR_ARGS="--data-path $DATA_PATH --checkpoint-path $CHECKPOINT_PATH --start-date $DETECT_START --end-date $DETECT_END --skip-mongodb --enrich-github"
+
+"$PYTHON" -m scripts.local.simple_detector $DETECTOR_ARGS
+
+# -----------------------------------------------------------------------------
+# Step 3: Run CopyCatch / Lockstep detector (optional for quick mode)
+# -----------------------------------------------------------------------------
+
+if [ "$MODE" != "quick" ]; then
+    echo ""
+    log "Step 3: Running CopyCatch / Lockstep detector..."
+    log "  This identifies coordinated starring behavior using overlapping"
+    log "  6-month time windows (chunks) as defined in scripts/__init__.py"
+    log "  WARNING: This can take hours/days for large date ranges"
+    echo ""
+
+    # The CopyCatch algorithm processes data in overlapping 6-month chunks
+    # to detect coordinated behavior. The chunks are defined in:
+    #   scripts/__init__.py -> COPYCATCH_DATE_CHUNKS
+    #
+    # For the 'research' mode, this matches the original paper's methodology.
+    # For shorter modes, only relevant chunks within the date range are used.
+
+    "$PYTHON" -m scripts.local.copycatch \
+        --data-path "$DATA_PATH" \
+        --checkpoint-path "$CHECKPOINT_PATH" \
+        --run
+
+    "$PYTHON" -m scripts.local.copycatch \
+        --data-path "$DATA_PATH" \
+        --checkpoint-path "$CHECKPOINT_PATH" \
+        --export
+else
+    echo ""
+    log "Step 3: Skipping CopyCatch (use 'month', 'year', or 'research' mode)"
+fi
+
+# -----------------------------------------------------------------------------
+# Results
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "=============================================="
+echo "Run Complete"
+echo "=============================================="
+echo ""
+log "Mode: $MODE"
+log "Results saved to: data/$DETECT_END/"
+echo ""
+
+if [ -f "data/$DETECT_END/fake_stars_low_activity_repos.csv" ]; then
+    REPO_COUNT=$(wc -l < "data/$DETECT_END/fake_stars_low_activity_repos.csv")
+    log "Found $((REPO_COUNT - 1)) repos with suspicious low-activity stars"
+    echo ""
+    echo "Top 10 repos by percentage of low-activity stars:"
+    head -11 "data/$DETECT_END/fake_stars_low_activity_repos.csv" | column -t -s,
+fi
+
+echo ""
+log "Cleaning up DuckDB temp files..."
+rm -rf "$TEMP_PATH"/* 2>/dev/null || true
+
+echo ""
+log "Storage usage:"
+du -sh "$DATA_PATH" "$CHECKPOINT_PATH" "$TEMP_PATH" 2>/dev/null || true
+

--- a/scripts/local/ingest/__init__.py
+++ b/scripts/local/ingest/__init__.py
@@ -1,0 +1,30 @@
+"""
+GitHub Archive ingestion pipeline configuration.
+
+Downloads hourly event data from gharchive.org and converts to
+partitioned Parquet files with Zstd compression.
+"""
+
+from pathlib import Path
+
+# Base URL for GitHub Archive hourly dumps
+GHARCHIVE_BASE_URL = "https://data.gharchive.org"
+
+# Default data directory (can be overridden via CLI or environment)
+DEFAULT_DATA_PATH = Path("data/gharchive")
+
+# Parquet compression settings
+PARQUET_COMPRESSION = "zstd"
+PARQUET_COMPRESSION_LEVEL = 3
+PARQUET_ROW_GROUP_SIZE = 100_000
+
+# Download settings
+DOWNLOAD_TIMEOUT = 60  # seconds
+DOWNLOAD_RETRIES = 3
+DOWNLOAD_RETRY_DELAY = 5  # seconds
+
+# Parallel processing
+DEFAULT_WORKERS = 4
+
+# State file for tracking ingestion progress
+STATE_FILE = "ingestion_state.json"

--- a/scripts/local/ingest/download.py
+++ b/scripts/local/ingest/download.py
@@ -1,0 +1,162 @@
+"""
+Download hourly GitHub Archive files.
+
+GitHub Archive provides hourly dumps at:
+https://data.gharchive.org/{YYYY}-{MM}-{DD}-{H}.json.gz
+
+Files are gzipped JSON with one event per line (NDJSON format).
+"""
+
+import gzip
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterator
+
+import requests
+
+from . import (
+    GHARCHIVE_BASE_URL,
+    DOWNLOAD_TIMEOUT,
+    DOWNLOAD_RETRIES,
+    DOWNLOAD_RETRY_DELAY,
+)
+
+
+def get_archive_url(dt: datetime) -> str:
+    """Get the GitHub Archive URL for a specific hour."""
+    # Format: YYYY-MM-DD-H (hour without leading zero)
+    return f"{GHARCHIVE_BASE_URL}/{dt.year}-{dt.month:02d}-{dt.day:02d}-{dt.hour}.json.gz"
+
+
+def iter_hours(start: datetime, end: datetime) -> Iterator[datetime]:
+    """Iterate over each hour in the date range (inclusive start, exclusive end)."""
+    current = start.replace(minute=0, second=0, microsecond=0)
+    end = end.replace(minute=0, second=0, microsecond=0)
+    while current < end:
+        yield current
+        current += timedelta(hours=1)
+
+
+def download_hour(dt: datetime, dest_dir: Path | None = None) -> bytes | Path:
+    """
+    Download a single hour's GitHub Archive data.
+
+    Args:
+        dt: The datetime for the hour to download
+        dest_dir: If provided, save to file and return path. Otherwise return bytes.
+
+    Returns:
+        Either the raw gzipped bytes or the path to the saved file.
+
+    Raises:
+        requests.HTTPError: If download fails after retries
+    """
+    url = get_archive_url(dt)
+
+    for attempt in range(DOWNLOAD_RETRIES):
+        try:
+            response = requests.get(url, timeout=DOWNLOAD_TIMEOUT, stream=True)
+            response.raise_for_status()
+
+            if dest_dir:
+                # Save to file
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                filename = f"{dt.year}-{dt.month:02d}-{dt.day:02d}-{dt.hour}.json.gz"
+                dest_path = dest_dir / filename
+                with open(dest_path, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                return dest_path
+            else:
+                # Return bytes
+                return response.content
+
+        except requests.RequestException as e:
+            if attempt < DOWNLOAD_RETRIES - 1:
+                time.sleep(DOWNLOAD_RETRY_DELAY * (attempt + 1))
+            else:
+                raise
+
+
+def download_hour_to_memory(dt: datetime) -> list[dict]:
+    """
+    Download and decompress a single hour's data into memory.
+
+    Returns:
+        List of event dictionaries parsed from the NDJSON.
+    """
+    import json
+
+    content = download_hour(dt)
+    if isinstance(content, Path):
+        with gzip.open(content, "rt", encoding="utf-8") as f:
+            lines = f.readlines()
+    else:
+        decompressed = gzip.decompress(content).decode("utf-8")
+        lines = decompressed.strip().split("\n")
+
+    events = []
+    for line in lines:
+        if line.strip():
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                # Skip malformed lines (rare but happens)
+                continue
+    return events
+
+
+def stream_hour_events(dt: datetime) -> Iterator[dict]:
+    """
+    Stream events from a GitHub Archive hour without loading all into memory.
+
+    Yields:
+        Event dictionaries one at a time.
+    """
+    import json
+
+    url = get_archive_url(dt)
+
+    for attempt in range(DOWNLOAD_RETRIES):
+        try:
+            response = requests.get(url, timeout=DOWNLOAD_TIMEOUT, stream=True)
+            response.raise_for_status()
+
+            # Decompress and parse line by line
+            decompressor = gzip.GzipFile(fileobj=response.raw)
+            buffer = b""
+
+            for chunk in iter(lambda: decompressor.read(8192), b""):
+                buffer += chunk
+                while b"\n" in buffer:
+                    line, buffer = buffer.split(b"\n", 1)
+                    if line.strip():
+                        try:
+                            yield json.loads(line.decode("utf-8"))
+                        except (json.JSONDecodeError, UnicodeDecodeError):
+                            continue
+
+            # Handle any remaining data in buffer
+            if buffer.strip():
+                try:
+                    yield json.loads(buffer.decode("utf-8"))
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    pass
+            return
+
+        except requests.RequestException as e:
+            if attempt < DOWNLOAD_RETRIES - 1:
+                time.sleep(DOWNLOAD_RETRY_DELAY * (attempt + 1))
+            else:
+                raise
+
+
+def check_hour_exists(dt: datetime) -> bool:
+    """Check if a GitHub Archive file exists for the given hour."""
+    url = get_archive_url(dt)
+    try:
+        response = requests.head(url, timeout=10)
+        return response.status_code == 200
+    except requests.RequestException:
+        return False

--- a/scripts/local/ingest/pipeline.py
+++ b/scripts/local/ingest/pipeline.py
@@ -1,0 +1,443 @@
+"""
+Main ingestion pipeline for GitHub Archive data.
+
+Usage:
+    # Backfill historical data
+    python -m scripts.local.ingest.pipeline --backfill 2024-01-01 2025-01-17
+
+    # Incremental update (since last ingested hour)
+    python -m scripts.local.ingest.pipeline --incremental
+
+    # Validate existing Parquet files
+    python -m scripts.local.ingest.pipeline --validate
+
+    # Retry failed hours
+    python -m scripts.local.ingest.pipeline --retry-failed
+"""
+
+import argparse
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from tqdm import tqdm
+
+from . import DEFAULT_DATA_PATH, DEFAULT_WORKERS
+from .download import iter_hours, stream_hour_events, check_hour_exists
+from .state import (
+    get_last_ingested,
+    set_last_ingested,
+    add_failed_hour,
+    clear_failed_hour,
+    get_failed_hours,
+    update_stats,
+    get_stats,
+    find_gaps,
+)
+from .transform import events_to_arrow
+from .write import write_table, parquet_exists, get_parquet_stats
+
+
+def ingest_hour(
+    dt: datetime,
+    base_path: Path,
+    minimal: bool = False,
+    skip_existing: bool = True,
+) -> dict:
+    """
+    Ingest a single hour of GitHub Archive data.
+
+    Args:
+        dt: The hour to ingest
+        base_path: Output directory for Parquet files
+        minimal: Use minimal schema (smaller files)
+        skip_existing: Skip if Parquet file already exists
+
+    Returns:
+        Dictionary with ingestion results:
+        - success: bool
+        - hour: ISO datetime string
+        - events: number of events processed
+        - bytes: size of output file
+        - error: error message if failed
+    """
+    result = {
+        "success": False,
+        "hour": dt.isoformat(),
+        "events": 0,
+        "bytes": 0,
+        "error": None,
+    }
+
+    try:
+        # Check if already ingested
+        if skip_existing and parquet_exists(base_path, dt):
+            stats = get_parquet_stats(base_path, dt)
+            result["success"] = True
+            result["events"] = stats.get("num_rows", 0)
+            result["bytes"] = stats.get("size_bytes", 0)
+            result["skipped"] = True
+            return result
+
+        # Check if source exists
+        if not check_hour_exists(dt):
+            result["error"] = f"No GitHub Archive data for {dt}"
+            return result
+
+        # Stream, transform, and write
+        events = stream_hour_events(dt)
+        table = events_to_arrow(events, dt, minimal=minimal)
+
+        if table.num_rows == 0:
+            result["error"] = f"No valid events for {dt}"
+            return result
+
+        output_path = write_table(table, base_path, dt)
+
+        result["success"] = True
+        result["events"] = table.num_rows
+        result["bytes"] = output_path.stat().st_size
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def backfill(
+    start: datetime,
+    end: datetime,
+    base_path: Path,
+    workers: int = DEFAULT_WORKERS,
+    minimal: bool = False,
+    skip_existing: bool = True,
+) -> dict:
+    """
+    Backfill historical data for a date range.
+
+    Args:
+        start: Start datetime (inclusive)
+        end: End datetime (exclusive)
+        base_path: Output directory
+        workers: Number of parallel workers
+        minimal: Use minimal schema
+        skip_existing: Skip hours that already have Parquet files
+
+    Returns:
+        Summary statistics
+    """
+    hours = list(iter_hours(start, end))
+    total = len(hours)
+
+    if total == 0:
+        print("No hours to process in the given range.")
+        return {"total": 0, "success": 0, "failed": 0}
+
+    print(f"Backfilling {total} hours from {start} to {end}")
+    print(f"Output: {base_path}")
+    print(f"Workers: {workers}")
+
+    success_count = 0
+    failed_count = 0
+    skipped_count = 0
+    total_events = 0
+    total_bytes = 0
+
+    # Use single worker for debugging, parallel for production
+    if workers == 1:
+        for hour in tqdm(hours, desc="Ingesting"):
+            result = ingest_hour(hour, base_path, minimal, skip_existing)
+            if result["success"]:
+                success_count += 1
+                total_events += result["events"]
+                total_bytes += result["bytes"]
+                if result.get("skipped"):
+                    skipped_count += 1
+                else:
+                    set_last_ingested(base_path, hour)
+            else:
+                failed_count += 1
+                if result["error"]:
+                    add_failed_hour(base_path, hour, result["error"])
+    else:
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(
+                    ingest_hour, hour, base_path, minimal, skip_existing
+                ): hour
+                for hour in hours
+            }
+
+            with tqdm(total=total, desc="Ingesting") as pbar:
+                for future in as_completed(futures):
+                    hour = futures[future]
+                    try:
+                        result = future.result()
+                        if result["success"]:
+                            success_count += 1
+                            total_events += result["events"]
+                            total_bytes += result["bytes"]
+                            if result.get("skipped"):
+                                skipped_count += 1
+                        else:
+                            failed_count += 1
+                            if result["error"]:
+                                add_failed_hour(base_path, hour, result["error"])
+                    except Exception as e:
+                        failed_count += 1
+                        add_failed_hour(base_path, hour, str(e))
+                    pbar.update(1)
+
+    # Update state with latest successful hour
+    if success_count > 0:
+        latest = max(
+            h for h in hours
+            if parquet_exists(base_path, h)
+        )
+        set_last_ingested(base_path, latest)
+
+    # Update cumulative stats
+    update_stats(
+        base_path,
+        hours=success_count - skipped_count,
+        events=total_events,
+        bytes_written=total_bytes,
+    )
+
+    summary = {
+        "total": total,
+        "success": success_count,
+        "skipped": skipped_count,
+        "failed": failed_count,
+        "events": total_events,
+        "bytes": total_bytes,
+    }
+
+    print(f"\nCompleted: {success_count}/{total} hours")
+    print(f"  Skipped (existing): {skipped_count}")
+    print(f"  Failed: {failed_count}")
+    print(f"  Events processed: {total_events:,}")
+    print(f"  Data written: {total_bytes / (1024**3):.2f} GB")
+
+    return summary
+
+
+def incremental(
+    base_path: Path,
+    workers: int = DEFAULT_WORKERS,
+    minimal: bool = False,
+) -> dict:
+    """
+    Ingest new data since the last successful ingestion.
+
+    Automatically determines the start point from saved state.
+    """
+    last = get_last_ingested(base_path)
+
+    if last is None:
+        # No previous ingestion - start from a reasonable default
+        # GitHub Archive starts in 2011, but we'll default to 2019 for StarScout
+        print("No previous ingestion found. Use --backfill to set initial range.")
+        return {"total": 0}
+
+    # Start from the hour after the last ingested
+    start = last + timedelta(hours=1)
+
+    # End at the current hour (GitHub Archive has ~1 hour delay)
+    now = datetime.now(timezone.utc)
+    end = now.replace(minute=0, second=0, microsecond=0)
+
+    if start >= end:
+        print(f"Already up to date. Last ingested: {last}")
+        return {"total": 0}
+
+    return backfill(start, end, base_path, workers, minimal)
+
+
+def retry_failed(
+    base_path: Path,
+    workers: int = DEFAULT_WORKERS,
+    minimal: bool = False,
+) -> dict:
+    """Retry all previously failed hours."""
+    failed = get_failed_hours(base_path)
+
+    if not failed:
+        print("No failed hours to retry.")
+        return {"total": 0}
+
+    print(f"Retrying {len(failed)} failed hours")
+
+    success_count = 0
+    still_failed = 0
+
+    for hour in tqdm(failed, desc="Retrying"):
+        result = ingest_hour(hour, base_path, minimal, skip_existing=False)
+        if result["success"]:
+            success_count += 1
+            clear_failed_hour(base_path, hour)
+        else:
+            still_failed += 1
+
+    print(f"Retry complete: {success_count} succeeded, {still_failed} still failing")
+    return {"success": success_count, "failed": still_failed}
+
+
+def validate(base_path: Path, start: datetime, end: datetime) -> dict:
+    """
+    Validate Parquet files in a date range.
+
+    Checks:
+    - Files exist for each hour
+    - Files are readable
+    - Files have expected schema
+    """
+    hours = list(iter_hours(start, end))
+    missing = []
+    invalid = []
+    valid = []
+
+    for hour in tqdm(hours, desc="Validating"):
+        if not parquet_exists(base_path, hour):
+            missing.append(hour)
+            continue
+
+        try:
+            stats = get_parquet_stats(base_path, hour)
+            if stats.get("num_rows", 0) == 0:
+                invalid.append((hour, "Empty file"))
+            else:
+                valid.append(hour)
+        except Exception as e:
+            invalid.append((hour, str(e)))
+
+    print(f"\nValidation complete:")
+    print(f"  Valid: {len(valid)}")
+    print(f"  Missing: {len(missing)}")
+    print(f"  Invalid: {len(invalid)}")
+
+    if missing:
+        print(f"\nFirst 10 missing hours:")
+        for h in missing[:10]:
+            print(f"    {h}")
+
+    if invalid:
+        print(f"\nFirst 10 invalid files:")
+        for h, err in invalid[:10]:
+            print(f"    {h}: {err}")
+
+    return {
+        "valid": len(valid),
+        "missing": len(missing),
+        "invalid": len(invalid),
+    }
+
+
+def parse_date(s: str) -> datetime:
+    """Parse a date string in YYYY-MM-DD format."""
+    return datetime.strptime(s, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Ingest GitHub Archive data to Parquet"
+    )
+
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=DEFAULT_DATA_PATH,
+        help=f"Base path for Parquet output (default: {DEFAULT_DATA_PATH})",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=DEFAULT_WORKERS,
+        help=f"Number of parallel workers (default: {DEFAULT_WORKERS})",
+    )
+    parser.add_argument(
+        "--minimal",
+        action="store_true",
+        help="Use minimal schema (smaller files, fewer fields)",
+    )
+
+    # Mutually exclusive operations
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--backfill",
+        nargs=2,
+        metavar=("START", "END"),
+        help="Backfill date range (YYYY-MM-DD YYYY-MM-DD)",
+    )
+    group.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Ingest new data since last successful run",
+    )
+    group.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="Retry previously failed hours",
+    )
+    group.add_argument(
+        "--validate",
+        nargs=2,
+        metavar=("START", "END"),
+        help="Validate Parquet files in date range",
+    )
+    group.add_argument(
+        "--stats",
+        action="store_true",
+        help="Show ingestion statistics",
+    )
+    group.add_argument(
+        "--gaps",
+        nargs=2,
+        metavar=("START", "END"),
+        help="Find missing hours in date range",
+    )
+
+    args = parser.parse_args()
+    base_path = args.data_path
+
+    if args.backfill:
+        start = parse_date(args.backfill[0])
+        end = parse_date(args.backfill[1])
+        backfill(start, end, base_path, args.workers, args.minimal)
+
+    elif args.incremental:
+        incremental(base_path, args.workers, args.minimal)
+
+    elif args.retry_failed:
+        retry_failed(base_path, args.workers, args.minimal)
+
+    elif args.validate:
+        start = parse_date(args.validate[0])
+        end = parse_date(args.validate[1])
+        validate(base_path, start, end)
+
+    elif args.stats:
+        stats = get_stats(base_path)
+        last = get_last_ingested(base_path)
+        failed = get_failed_hours(base_path)
+
+        print(f"Ingestion Statistics for {base_path}")
+        print(f"  Last ingested: {last or 'None'}")
+        print(f"  Total hours: {stats.get('total_hours_ingested', 0):,}")
+        print(f"  Total events: {stats.get('total_events_processed', 0):,}")
+        print(f"  Total bytes: {stats.get('total_bytes_written', 0) / (1024**3):.2f} GB")
+        print(f"  Failed hours pending: {len(failed)}")
+
+    elif args.gaps:
+        start = parse_date(args.gaps[0])
+        end = parse_date(args.gaps[1])
+        gaps = find_gaps(base_path, start, end)
+        print(f"Found {len(gaps)} missing hours between {start.date()} and {end.date()}")
+        if gaps and len(gaps) <= 20:
+            for g in gaps:
+                print(f"  {g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local/ingest/schema.py
+++ b/scripts/local/ingest/schema.py
@@ -1,0 +1,80 @@
+"""
+PyArrow schema definition for GitHub Archive events.
+
+This schema flattens the nested JSON structure from GitHub Archive
+into a columnar format optimized for the StarScout queries.
+"""
+
+import pyarrow as pa
+
+# Core event schema matching StarScout query requirements
+EVENTS_SCHEMA = pa.schema([
+    # Event identification
+    ("id", pa.string()),  # Event ID (string in GitHub Archive)
+    ("type", pa.string()),  # Event type: WatchEvent, PushEvent, etc.
+    ("created_at", pa.timestamp("us", tz="UTC")),  # Event timestamp
+
+    # Actor (user) fields
+    ("actor_id", pa.int64()),
+    ("actor_login", pa.string()),
+    ("actor_avatar_url", pa.string()),
+
+    # Repository fields
+    ("repo_id", pa.int64()),
+    ("repo_name", pa.string()),  # Format: owner/repo
+
+    # Organization fields (nullable - not all events have org)
+    ("org_id", pa.int64()),
+    ("org_login", pa.string()),
+
+    # Derived field for efficient star queries
+    ("is_star", pa.bool_()),  # True if WatchEvent with action=started
+
+    # Partition columns (duplicated for Hive partitioning)
+    ("year", pa.int16()),
+    ("month", pa.int8()),
+    ("day", pa.int8()),
+    ("hour", pa.int8()),
+])
+
+# Event types we care about for StarScout
+# WatchEvent = star, others used for activity analysis
+RELEVANT_EVENT_TYPES = {
+    "WatchEvent",      # Star/unstar
+    "PushEvent",       # Code push
+    "IssuesEvent",     # Issue actions
+    "PullRequestEvent",  # PR actions
+    "CreateEvent",     # Branch/tag/repo creation
+    "DeleteEvent",     # Branch/tag deletion
+    "ForkEvent",       # Repository fork
+    "IssueCommentEvent",  # Issue comments
+    "CommitCommentEvent",  # Commit comments
+    "PullRequestReviewEvent",  # PR reviews
+    "PullRequestReviewCommentEvent",  # PR review comments
+    "ReleaseEvent",    # Release actions
+    "MemberEvent",     # Collaborator changes
+    "PublicEvent",     # Repo made public
+    "GollumEvent",     # Wiki edits
+}
+
+# Minimal schema for memory-efficient processing
+# Only includes fields actually used in queries
+MINIMAL_SCHEMA = pa.schema([
+    ("type", pa.string()),
+    ("created_at", pa.timestamp("us", tz="UTC")),
+    ("actor_id", pa.int64()),
+    ("actor_login", pa.string()),
+    ("repo_id", pa.int64()),
+    ("repo_name", pa.string()),
+    ("org_login", pa.string()),
+    ("is_star", pa.bool_()),
+    ("year", pa.int16()),
+    ("month", pa.int8()),
+    ("day", pa.int8()),
+    ("hour", pa.int8()),
+])
+
+
+def get_schema(minimal: bool = False) -> pa.Schema:
+    """Get the appropriate schema for Parquet files."""
+    return MINIMAL_SCHEMA if minimal else EVENTS_SCHEMA

--- a/scripts/local/ingest/state.py
+++ b/scripts/local/ingest/state.py
@@ -1,0 +1,145 @@
+"""
+State management for incremental ingestion.
+
+Tracks:
+- Last successfully ingested hour
+- Failed hours for retry
+- Ingestion statistics
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from . import STATE_FILE
+
+
+def get_state_path(base_path: Path) -> Path:
+    """Get the path to the state file."""
+    return base_path / STATE_FILE
+
+
+def load_state(base_path: Path) -> dict:
+    """
+    Load ingestion state from disk.
+
+    Returns:
+        State dictionary with keys:
+        - last_ingested: ISO format datetime string of last successful hour
+        - failed_hours: List of ISO format datetime strings that failed
+        - stats: Ingestion statistics
+    """
+    state_path = get_state_path(base_path)
+
+    if not state_path.exists():
+        return {
+            "last_ingested": None,
+            "failed_hours": [],
+            "stats": {
+                "total_hours_ingested": 0,
+                "total_events_processed": 0,
+                "total_bytes_written": 0,
+            },
+        }
+
+    with open(state_path, "r") as f:
+        return json.load(f)
+
+
+def save_state(base_path: Path, state: dict) -> None:
+    """Save ingestion state to disk."""
+    state_path = get_state_path(base_path)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(state_path, "w") as f:
+        json.dump(state, f, indent=2, default=str)
+
+
+def get_last_ingested(base_path: Path) -> Optional[datetime]:
+    """Get the last successfully ingested hour."""
+    state = load_state(base_path)
+    last = state.get("last_ingested")
+    if last:
+        return datetime.fromisoformat(last)
+    return None
+
+
+def set_last_ingested(base_path: Path, dt: datetime) -> None:
+    """Update the last successfully ingested hour."""
+    state = load_state(base_path)
+    state["last_ingested"] = dt.isoformat()
+    save_state(base_path, state)
+
+
+def add_failed_hour(base_path: Path, dt: datetime, error: str) -> None:
+    """Record a failed hour for later retry."""
+    state = load_state(base_path)
+    failed = state.get("failed_hours", [])
+
+    # Add with error info
+    failed.append({
+        "hour": dt.isoformat(),
+        "error": str(error),
+        "attempts": 1,
+    })
+
+    state["failed_hours"] = failed
+    save_state(base_path, state)
+
+
+def get_failed_hours(base_path: Path) -> list[datetime]:
+    """Get list of hours that failed ingestion."""
+    state = load_state(base_path)
+    failed = state.get("failed_hours", [])
+    return [datetime.fromisoformat(f["hour"]) for f in failed]
+
+
+def clear_failed_hour(base_path: Path, dt: datetime) -> None:
+    """Remove an hour from the failed list (after successful retry)."""
+    state = load_state(base_path)
+    failed = state.get("failed_hours", [])
+    state["failed_hours"] = [
+        f for f in failed if f["hour"] != dt.isoformat()
+    ]
+    save_state(base_path, state)
+
+
+def update_stats(
+    base_path: Path,
+    hours: int = 0,
+    events: int = 0,
+    bytes_written: int = 0,
+) -> None:
+    """Update cumulative ingestion statistics."""
+    state = load_state(base_path)
+    stats = state.get("stats", {})
+
+    stats["total_hours_ingested"] = stats.get("total_hours_ingested", 0) + hours
+    stats["total_events_processed"] = stats.get("total_events_processed", 0) + events
+    stats["total_bytes_written"] = stats.get("total_bytes_written", 0) + bytes_written
+
+    state["stats"] = stats
+    save_state(base_path, state)
+
+
+def get_stats(base_path: Path) -> dict:
+    """Get ingestion statistics."""
+    state = load_state(base_path)
+    return state.get("stats", {})
+
+
+def find_gaps(base_path: Path, start: datetime, end: datetime) -> list[datetime]:
+    """
+    Find hours in the range that are missing Parquet files.
+
+    Useful for identifying incomplete ingestions.
+    """
+    from .download import iter_hours
+    from .write import parquet_exists
+
+    gaps = []
+    for hour in iter_hours(start, end):
+        if not parquet_exists(base_path, hour):
+            gaps.append(hour)
+    return gaps

--- a/scripts/local/ingest/transform.py
+++ b/scripts/local/ingest/transform.py
@@ -1,0 +1,162 @@
+"""
+Transform GitHub Archive JSON events to PyArrow tables.
+
+Handles:
+- Flattening nested JSON structure (actor.login -> actor_login)
+- Computing derived fields (is_star)
+- Schema evolution across GitHub Archive history
+- Missing/null field handling
+"""
+
+from datetime import datetime
+from typing import Iterator
+
+import pyarrow as pa
+
+from .schema import EVENTS_SCHEMA, MINIMAL_SCHEMA
+
+
+def extract_event_fields(event: dict, hour_dt: datetime) -> dict | None:
+    """
+    Extract and flatten fields from a GitHub Archive event.
+
+    Args:
+        event: Raw event dictionary from GitHub Archive
+        hour_dt: The hour this event belongs to (for partitioning)
+
+    Returns:
+        Flattened dictionary matching our schema, or None if event is malformed.
+    """
+    try:
+        # Core fields
+        event_type = event.get("type", "")
+        created_at_str = event.get("created_at")
+
+        if not event_type or not created_at_str:
+            return None
+
+        # Parse timestamp
+        # GitHub Archive uses ISO format: 2024-01-15T12:34:56Z
+        try:
+            created_at = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            return None
+
+        # Actor fields (with fallbacks for schema evolution)
+        actor = event.get("actor", {}) or {}
+        actor_id = actor.get("id")
+        actor_login = actor.get("login") or actor.get("display_login")
+
+        # In very old events, actor might be just a string
+        if isinstance(event.get("actor"), str):
+            actor_login = event["actor"]
+            actor_id = None
+
+        if not actor_login:
+            return None
+
+        # Repo fields
+        repo = event.get("repo", {}) or {}
+        repo_id = repo.get("id")
+        repo_name = repo.get("name")
+
+        # Old format: repository.owner + repository.name
+        if not repo_name:
+            repository = event.get("repository", {}) or {}
+            if repository:
+                owner = repository.get("owner")
+                name = repository.get("name")
+                if owner and name:
+                    repo_name = f"{owner}/{name}"
+                repo_id = repository.get("id")
+
+        if not repo_name:
+            return None
+
+        # Org fields (nullable)
+        org = event.get("org", {}) or {}
+        org_id = org.get("id")
+        org_login = org.get("login")
+
+        # Determine if this is a star event
+        # WatchEvent with action="started" is a star
+        is_star = False
+        if event_type == "WatchEvent":
+            payload = event.get("payload", {}) or {}
+            action = payload.get("action", "")
+            # "started" means star, empty or "started" in old format
+            is_star = action in ("started", "")
+
+        return {
+            "id": str(event.get("id", "")),
+            "type": event_type,
+            "created_at": created_at,
+            "actor_id": int(actor_id) if actor_id else None,
+            "actor_login": actor_login,
+            "actor_avatar_url": actor.get("avatar_url"),
+            "repo_id": int(repo_id) if repo_id else None,
+            "repo_name": repo_name,
+            "org_id": int(org_id) if org_id else None,
+            "org_login": org_login,
+            "is_star": is_star,
+            "year": hour_dt.year,
+            "month": hour_dt.month,
+            "day": hour_dt.day,
+            "hour": hour_dt.hour,
+        }
+
+    except Exception:
+        # Skip any malformed events
+        return None
+
+
+def events_to_arrow(
+    events: Iterator[dict],
+    hour_dt: datetime,
+    minimal: bool = False,
+) -> pa.Table:
+    """
+    Convert an iterator of GitHub Archive events to a PyArrow table.
+
+    Args:
+        events: Iterator of raw event dictionaries
+        hour_dt: The hour these events belong to
+        minimal: If True, use minimal schema (smaller files)
+
+    Returns:
+        PyArrow table with flattened event data
+    """
+    schema = MINIMAL_SCHEMA if minimal else EVENTS_SCHEMA
+
+    # Collect rows
+    rows = {field.name: [] for field in schema}
+
+    for event in events:
+        extracted = extract_event_fields(event, hour_dt)
+        if extracted is None:
+            continue
+
+        for field in schema:
+            value = extracted.get(field.name)
+            rows[field.name].append(value)
+
+    # Build arrays
+    arrays = []
+    for field in schema:
+        arr = pa.array(rows[field.name], type=field.type)
+        arrays.append(arr)
+
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def transform_hour(
+    events: list[dict],
+    hour_dt: datetime,
+    minimal: bool = False,
+) -> pa.Table:
+    """
+    Transform a list of events for a single hour into a PyArrow table.
+
+    This is a convenience wrapper around events_to_arrow for batch processing.
+    """
+    return events_to_arrow(iter(events), hour_dt, minimal)

--- a/scripts/local/ingest/write.py
+++ b/scripts/local/ingest/write.py
@@ -1,0 +1,148 @@
+"""
+Write PyArrow tables to Parquet files with Hive partitioning.
+
+Output structure:
+    {base_path}/year=YYYY/month=MM/day=DD/HH.parquet
+
+Uses Zstd compression for optimal size/speed balance.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from . import (
+    PARQUET_COMPRESSION,
+    PARQUET_COMPRESSION_LEVEL,
+    PARQUET_ROW_GROUP_SIZE,
+)
+
+
+def get_partition_path(base_path: Path, dt: datetime) -> Path:
+    """
+    Get the Hive-partitioned directory path for a given hour.
+
+    Returns:
+        Path like: {base_path}/year=2024/month=01/day=15/
+    """
+    return (
+        base_path
+        / f"year={dt.year}"
+        / f"month={dt.month:02d}"
+        / f"day={dt.day:02d}"
+    )
+
+
+def get_parquet_path(base_path: Path, dt: datetime) -> Path:
+    """
+    Get the full Parquet file path for a given hour.
+
+    Returns:
+        Path like: {base_path}/year=2024/month=01/day=15/14.parquet
+    """
+    partition_dir = get_partition_path(base_path, dt)
+    return partition_dir / f"{dt.hour:02d}.parquet"
+
+
+def write_table(
+    table: pa.Table,
+    base_path: Path,
+    dt: datetime,
+    compression: str = PARQUET_COMPRESSION,
+    compression_level: int = PARQUET_COMPRESSION_LEVEL,
+    row_group_size: int = PARQUET_ROW_GROUP_SIZE,
+) -> Path:
+    """
+    Write a PyArrow table to a Parquet file.
+
+    Args:
+        table: The PyArrow table to write
+        base_path: Base directory for partitioned data
+        dt: The hour this data represents (used for path)
+        compression: Compression codec (default: zstd)
+        compression_level: Compression level (default: 3)
+        row_group_size: Rows per row group (default: 100K)
+
+    Returns:
+        Path to the written Parquet file
+    """
+    output_path = get_parquet_path(base_path, dt)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Remove partition columns from the table data
+    # (they're encoded in the path, not needed in the file)
+    columns_to_drop = ["year", "month", "day", "hour"]
+    columns_to_keep = [
+        col for col in table.column_names if col not in columns_to_drop
+    ]
+    table_to_write = table.select(columns_to_keep)
+
+    pq.write_table(
+        table_to_write,
+        output_path,
+        compression=compression,
+        compression_level=compression_level,
+        row_group_size=row_group_size,
+        # Write statistics for all columns (helps query optimization)
+        write_statistics=True,
+        # Use data page v2 for better compression
+        data_page_version="2.0",
+    )
+
+    return output_path
+
+
+def write_dataset(
+    tables: dict[datetime, pa.Table],
+    base_path: Path,
+    **kwargs,
+) -> list[Path]:
+    """
+    Write multiple tables as a partitioned dataset.
+
+    Args:
+        tables: Dictionary mapping datetime -> PyArrow table
+        base_path: Base directory for output
+        **kwargs: Additional arguments passed to write_table
+
+    Returns:
+        List of paths to written Parquet files
+    """
+    paths = []
+    for dt, table in tables.items():
+        path = write_table(table, base_path, dt, **kwargs)
+        paths.append(path)
+    return paths
+
+
+def parquet_exists(base_path: Path, dt: datetime) -> bool:
+    """Check if a Parquet file already exists for the given hour."""
+    return get_parquet_path(base_path, dt).exists()
+
+
+def read_parquet(base_path: Path, dt: datetime) -> pa.Table:
+    """Read a Parquet file for the given hour."""
+    path = get_parquet_path(base_path, dt)
+    if not path.exists():
+        raise FileNotFoundError(f"No Parquet file for {dt}: {path}")
+    return pq.read_table(path)
+
+
+def get_parquet_stats(base_path: Path, dt: datetime) -> dict:
+    """Get metadata and statistics for a Parquet file."""
+    path = get_parquet_path(base_path, dt)
+    if not path.exists():
+        return {"exists": False}
+
+    metadata = pq.read_metadata(path)
+    return {
+        "exists": True,
+        "path": str(path),
+        "size_bytes": path.stat().st_size,
+        "num_rows": metadata.num_rows,
+        "num_row_groups": metadata.num_row_groups,
+        "num_columns": metadata.num_columns,
+        "created_by": metadata.created_by,
+    }

--- a/scripts/local/queries.py
+++ b/scripts/local/queries.py
@@ -1,0 +1,332 @@
+"""
+Query execution utilities for local DuckDB processing.
+
+Provides helpers for:
+- Reading from partitioned Parquet files
+- Executing SQL with parameter substitution
+- Writing results to Parquet/CSV
+- Managing intermediate checkpoint tables
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from . import get_connection, DEFAULT_DATA_PATH, DEFAULT_CHECKPOINT_PATH
+
+
+def date_to_yymmdd(dt: datetime) -> str:
+    """Convert datetime to YYMMDD format used in StarScout."""
+    return dt.strftime("%y%m%d")
+
+
+def yymmdd_to_date(s: str) -> datetime:
+    """Convert YYMMDD string to datetime."""
+    return datetime.strptime(s, "%y%m%d")
+
+
+def get_parquet_glob(
+    data_path: Path = DEFAULT_DATA_PATH,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
+    """
+    Get a glob pattern for Parquet files in a date range.
+
+    For DuckDB, we use the read_parquet function with hive_partitioning=true,
+    which automatically handles partition pruning based on WHERE clauses.
+
+    Returns a glob pattern like: 'data/gharchive/**/*.parquet'
+    """
+    return str(data_path / "**" / "*.parquet")
+
+
+def build_date_filter(
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
+    """
+    Build a SQL WHERE clause for date filtering.
+
+    Args:
+        start_date: Start date in YYMMDD format (inclusive)
+        end_date: End date in YYMMDD format (exclusive)
+
+    Returns:
+        SQL fragment like "created_at >= '2024-01-01' AND created_at < '2025-01-01'"
+    """
+    conditions = []
+
+    if start_date:
+        dt = yymmdd_to_date(start_date)
+        conditions.append(f"created_at >= '{dt.strftime('%Y-%m-%d')}'")
+
+    if end_date:
+        dt = yymmdd_to_date(end_date)
+        conditions.append(f"created_at < '{dt.strftime('%Y-%m-%d')}'")
+
+    if conditions:
+        return " AND ".join(conditions)
+    return "1=1"
+
+
+def execute_query(
+    sql: str,
+    params: dict[str, Any] | None = None,
+    data_path: Path = DEFAULT_DATA_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> duckdb.DuckDBPyRelation:
+    """
+    Execute a SQL query with parameter substitution.
+
+    Parameters in the SQL should be formatted as {param_name}.
+
+    Args:
+        sql: SQL query with optional {param} placeholders
+        params: Dictionary of parameter values
+        data_path: Base path for Parquet files
+        con: Optional DuckDB connection (uses global if not provided)
+
+    Returns:
+        DuckDB relation (lazy evaluation)
+    """
+    if con is None:
+        con = get_connection()
+
+    # Default parameters
+    all_params = {
+        "parquet_glob": get_parquet_glob(data_path),
+        "data_path": str(data_path),
+    }
+    if params:
+        all_params.update(params)
+
+    # Substitute parameters
+    formatted_sql = sql.format(**all_params)
+
+    return con.sql(formatted_sql)
+
+
+def query_to_df(
+    sql: str,
+    params: dict[str, Any] | None = None,
+    data_path: Path = DEFAULT_DATA_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> pd.DataFrame:
+    """Execute a query and return results as a pandas DataFrame."""
+    result = execute_query(sql, params, data_path, con)
+    return result.df()
+
+
+def query_to_arrow(
+    sql: str,
+    params: dict[str, Any] | None = None,
+    data_path: Path = DEFAULT_DATA_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> pa.Table:
+    """Execute a query and return results as a PyArrow table."""
+    result = execute_query(sql, params, data_path, con)
+    return result.arrow()
+
+
+def query_to_parquet(
+    sql: str,
+    output_path: Path,
+    params: dict[str, Any] | None = None,
+    data_path: Path = DEFAULT_DATA_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+    compression: str = "zstd",
+) -> Path:
+    """
+    Execute a query and write results to a Parquet file.
+
+    Uses DuckDB's native COPY TO for efficiency.
+    """
+    if con is None:
+        con = get_connection()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Build the full query with COPY TO
+    all_params = {
+        "parquet_glob": get_parquet_glob(data_path),
+        "data_path": str(data_path),
+    }
+    if params:
+        all_params.update(params)
+
+    formatted_sql = sql.format(**all_params)
+
+    copy_sql = f"""
+        COPY (
+            {formatted_sql}
+        ) TO '{output_path}' (FORMAT PARQUET, COMPRESSION {compression})
+    """
+
+    con.execute(copy_sql)
+    return output_path
+
+
+def query_to_csv(
+    sql: str,
+    output_path: Path,
+    params: dict[str, Any] | None = None,
+    data_path: Path = DEFAULT_DATA_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> Path:
+    """Execute a query and write results to a CSV file."""
+    if con is None:
+        con = get_connection()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    all_params = {
+        "parquet_glob": get_parquet_glob(data_path),
+        "data_path": str(data_path),
+    }
+    if params:
+        all_params.update(params)
+
+    formatted_sql = sql.format(**all_params)
+
+    copy_sql = f"""
+        COPY (
+            {formatted_sql}
+        ) TO '{output_path}' (FORMAT CSV, HEADER)
+    """
+
+    con.execute(copy_sql)
+    return output_path
+
+
+def create_checkpoint_table(
+    name: str,
+    sql: str,
+    params: dict[str, Any] | None = None,
+    checkpoint_path: Path = DEFAULT_CHECKPOINT_PATH,
+    data_path: Path = DEFAULT_DATA_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> Path:
+    """
+    Execute a query and save results as a checkpoint Parquet file.
+
+    Checkpoints are used for intermediate results in multi-step pipelines.
+    """
+    output_path = checkpoint_path / f"{name}.parquet"
+    return query_to_parquet(sql, output_path, params, data_path, con)
+
+
+def load_checkpoint_table(
+    name: str,
+    checkpoint_path: Path = DEFAULT_CHECKPOINT_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> duckdb.DuckDBPyRelation:
+    """Load a checkpoint table as a DuckDB relation."""
+    if con is None:
+        con = get_connection()
+
+    parquet_path = checkpoint_path / f"{name}.parquet"
+    if not parquet_path.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {parquet_path}")
+
+    return con.read_parquet(str(parquet_path))
+
+
+def checkpoint_exists(
+    name: str,
+    checkpoint_path: Path = DEFAULT_CHECKPOINT_PATH,
+) -> bool:
+    """Check if a checkpoint file exists."""
+    return (checkpoint_path / f"{name}.parquet").exists()
+
+
+def register_parquet_view(
+    view_name: str,
+    data_path: Path = DEFAULT_DATA_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> None:
+    """
+    Register the Parquet files as a view for easier querying.
+
+    After calling this, you can query using:
+        SELECT * FROM {view_name} WHERE ...
+    """
+    if con is None:
+        con = get_connection()
+
+    glob_pattern = get_parquet_glob(data_path)
+    con.execute(f"""
+        CREATE OR REPLACE VIEW {view_name} AS
+        SELECT * FROM read_parquet('{glob_pattern}', hive_partitioning=true)
+    """)
+
+
+def get_date_range_from_parquet(
+    data_path: Path = DEFAULT_DATA_PATH,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> tuple[datetime, datetime]:
+    """Get the min and max dates available in the Parquet files."""
+    if con is None:
+        con = get_connection()
+
+    glob_pattern = get_parquet_glob(data_path)
+    result = con.execute(f"""
+        SELECT
+            MIN(created_at) as min_date,
+            MAX(created_at) as max_date
+        FROM read_parquet('{glob_pattern}', hive_partitioning=true)
+    """).fetchone()
+
+    return result[0], result[1]
+
+
+def count_events(
+    data_path: Path = DEFAULT_DATA_PATH,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    event_type: str | None = None,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> int:
+    """Count events matching the criteria."""
+    if con is None:
+        con = get_connection()
+
+    glob_pattern = get_parquet_glob(data_path)
+    date_filter = build_date_filter(start_date, end_date)
+
+    type_filter = f"AND type = '{event_type}'" if event_type else ""
+
+    result = con.execute(f"""
+        SELECT COUNT(*)
+        FROM read_parquet('{glob_pattern}', hive_partitioning=true)
+        WHERE {date_filter} {type_filter}
+    """).fetchone()
+
+    return result[0]
+
+
+def count_stars(
+    data_path: Path = DEFAULT_DATA_PATH,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    con: duckdb.DuckDBPyConnection | None = None,
+) -> int:
+    """Count star events in the date range."""
+    if con is None:
+        con = get_connection()
+
+    glob_pattern = get_parquet_glob(data_path)
+    date_filter = build_date_filter(start_date, end_date)
+
+    result = con.execute(f"""
+        SELECT COUNT(*)
+        FROM read_parquet('{glob_pattern}', hive_partitioning=true)
+        WHERE is_star = true AND {date_filter}
+    """).fetchone()
+
+    return result[0]

--- a/scripts/local/requirements.txt
+++ b/scripts/local/requirements.txt
@@ -1,0 +1,19 @@
+# Minimal requirements for local execution (scripts/local/)
+# Use this instead of requirements.txt to avoid heavy/unused dependencies
+
+# Core
+pandas
+pyyaml
+tqdm
+requests
+python-dateutil
+
+# Local execution (DuckDB + Parquet)
+pyarrow
+duckdb
+
+# MongoDB export (optional - fails gracefully if not available)
+pymongo
+
+# GitHub API enrichment (optional - fails gracefully if not available)
+strudel.scraper

--- a/scripts/local/simple_detector.py
+++ b/scripts/local/simple_detector.py
@@ -58,15 +58,16 @@ def enrich_repos_with_github_api(repos: pd.DataFrame) -> pd.DataFrame:
     logging.info(f"Enriching {len(repos)} repos with GitHub API data...")
     logging.info(f"Using {len(GITHUB_TOKENS)} GitHub token(s) for rate limit rotation")
 
-    # Add repo_id column
     from tqdm import tqdm
-    tqdm.pandas(desc="Fetching repo IDs")
     repos = repos.copy()
-    repos.insert(0, "repo_id", repos.repo_name.progress_apply(get_repo_id))
+
+    # Add repo_id column
+    repo_ids = [get_repo_id(name) for name in tqdm(repos.repo_name, desc="Fetching repo IDs")]
+    repos.insert(0, "repo_id", repo_ids)
 
     # Add current star count
-    tqdm.pandas(desc="Fetching current stars")
-    repos["n_stars_latest"] = repos.repo_name.progress_apply(get_repo_n_stars_latest)
+    star_counts = [get_repo_n_stars_latest(name) for name in tqdm(repos.repo_name, desc="Fetching current stars")]
+    repos["n_stars_latest"] = star_counts
 
     # Log summary
     n_found = repos.repo_id.notna().sum()

--- a/scripts/local/simple_detector.py
+++ b/scripts/local/simple_detector.py
@@ -1,0 +1,324 @@
+"""
+Low-activity fake star detector using local DuckDB execution.
+
+This is the local version of simple_detector_bigquery.py that reads
+from Parquet files instead of BigQuery.
+
+Usage:
+    python -m scripts.local.simple_detector
+    python -m scripts.local.simple_detector --start-date 240701 --end-date 250101
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pymongo
+
+from scripts import (
+    GITHUB_TOKENS,
+    MONGO_URL,
+    START_DATE,
+    END_DATE,
+    MIN_STARS_LOW_ACTIVITY,
+)
+from . import DEFAULT_DATA_PATH, DEFAULT_CHECKPOINT_PATH
+from .queries import (
+    query_to_df,
+    query_to_parquet,
+    yymmdd_to_date,
+)
+
+
+def enrich_repos_with_github_api(repos: pd.DataFrame) -> pd.DataFrame:
+    """
+    Enrich repos DataFrame with current GitHub API data.
+
+    Adds columns:
+    - repo_id: GitHub GraphQL node ID
+    - n_stars_latest: Current star count from GitHub API
+
+    Requires GITHUB_TOKENS to be configured in secrets.yaml.
+    Requires strudel.scraper package: pip install strudel.scraper
+    """
+    if not GITHUB_TOKENS:
+        logging.info("Skipping GitHub API enrichment (no tokens in secrets.yaml)")
+        return repos
+
+    # Lazy import - only load when actually using enrichment
+    try:
+        from scripts.github import get_repo_id, get_repo_n_stars_latest
+    except ImportError:
+        logging.info("Skipping GitHub API enrichment (strudel.scraper not installed)")
+        return repos
+
+    logging.info(f"Enriching {len(repos)} repos with GitHub API data...")
+    logging.info(f"Using {len(GITHUB_TOKENS)} GitHub token(s) for rate limit rotation")
+
+    # Add repo_id column
+    from tqdm import tqdm
+    tqdm.pandas(desc="Fetching repo IDs")
+    repos = repos.copy()
+    repos.insert(0, "repo_id", repos.repo_name.progress_apply(get_repo_id))
+
+    # Add current star count
+    tqdm.pandas(desc="Fetching current stars")
+    repos["n_stars_latest"] = repos.repo_name.progress_apply(get_repo_n_stars_latest)
+
+    # Log summary
+    n_found = repos.repo_id.notna().sum()
+    n_missing = repos.repo_id.isna().sum()
+    logging.info(f"GitHub API enrichment complete: {n_found} repos found, {n_missing} deleted/private")
+
+    return repos
+
+
+def get_repos_with_low_activity_stars(
+    start_date: str,
+    end_date: str,
+    min_stars: int,
+    data_path: Path,
+    checkpoint_path: Path,
+) -> pd.DataFrame:
+    """
+    Find repositories with low-activity stargazers.
+
+    Returns DataFrame with columns: repo_name, n_stars, low_activity_actors
+    """
+    logging.info(f"Finding repos with low-activity stars ({start_date} to {end_date})")
+
+    sql = Path("scripts/local/sql/dagster/stg_all_repos_with_low_activity_stars.sql").read_text()
+
+    # Convert YYMMDD to YYYY-MM-DD for DuckDB
+    start_dt = yymmdd_to_date(start_date)
+    end_dt = yymmdd_to_date(end_date)
+
+    result = query_to_df(
+        sql,
+        params={
+            "start_date": start_dt.strftime("%Y-%m-%d"),
+            "end_date": end_dt.strftime("%Y-%m-%d"),
+            "min_stars_low_activity": min_stars,
+        },
+        data_path=data_path,
+    )
+
+    logging.info(f"Found {len(result)} repositories with >= {min_stars} low-activity stars")
+
+    # Save checkpoint
+    checkpoint_file = checkpoint_path / f"repos_with_low_activity_stars_{start_date}_{end_date}.parquet"
+    checkpoint_path.mkdir(parents=True, exist_ok=True)
+    result.to_parquet(checkpoint_file, compression="zstd")
+    logging.info(f"Saved checkpoint: {checkpoint_file}")
+
+    return result
+
+
+def get_low_activity_stars(
+    start_date: str,
+    end_date: str,
+    data_path: Path,
+    checkpoint_path: Path,
+) -> pd.DataFrame:
+    """
+    Get individual low-activity star records.
+
+    Returns DataFrame with columns: actor, repo, starred_at, low_activity
+    """
+    logging.info(f"Extracting low-activity star records ({start_date} to {end_date})")
+
+    sql = Path("scripts/local/sql/dagster/stg_low_activity_stargazers.sql").read_text()
+
+    # Convert YYMMDD to YYYY-MM-DD for DuckDB
+    start_dt = yymmdd_to_date(start_date)
+    end_dt = yymmdd_to_date(end_date)
+
+    repos_checkpoint = checkpoint_path / f"repos_with_low_activity_stars_{start_date}_{end_date}.parquet"
+
+    result = query_to_df(
+        sql,
+        params={
+            "start_date": start_dt.strftime("%Y-%m-%d"),
+            "end_date": end_dt.strftime("%Y-%m-%d"),
+            "repos_checkpoint": str(repos_checkpoint),
+        },
+        data_path=data_path,
+    )
+
+    logging.info(f"Found {len(result)} low-activity star records")
+
+    return result
+
+
+def dump_repos_csv(
+    repos: pd.DataFrame,
+    output_dir: Path,
+) -> Path:
+    """
+    Save repositories to CSV file.
+
+    Note: Unlike the BigQuery version, we skip GitHub API calls for repo_id
+    and n_stars_latest since those are rate-limited and slow.
+    """
+    logging.info("Saving repositories to CSV")
+
+    # Calculate statistics
+    repos = repos.copy()
+    repos["n_stars_low_activity"] = repos["low_activity_actors"].apply(
+        lambda x: len(set(x)) if x is not None else 0
+    )
+    repos["p_stars_low_activity"] = repos["n_stars_low_activity"] / repos["n_stars"]
+
+    # Sort by percentage of low-activity stars
+    repos.sort_values(by="p_stars_low_activity", ascending=False, inplace=True)
+
+    # Drop the actors list (too large for CSV)
+    repos_out = repos.drop(columns=["low_activity_actors"])
+
+    output_path = output_dir / "fake_stars_low_activity_repos.csv"
+    repos_out.to_csv(output_path, index=False)
+    logging.info(f"Saved: {output_path}")
+
+    return output_path
+
+
+def dump_stars_mongodb(
+    stars: pd.DataFrame,
+    mongo_url: str,
+) -> int:
+    """
+    Save star records to MongoDB.
+
+    Returns number of records inserted.
+    """
+    logging.info("Saving star records to MongoDB")
+
+    client = pymongo.MongoClient(mongo_url)
+    db = client.get_database("fake_stars")
+
+    # Drop existing collection and recreate with index
+    db.low_activity_stars.drop()
+    db.low_activity_stars.create_index(
+        ["repo", "actor", "starred_at"],
+        unique=True,
+    )
+
+    # Convert DataFrame to records
+    records = []
+    seen = set()
+    for _, row in stars.iterrows():
+        key = f"{row['repo']}|{row['actor']}|{row['starred_at']}"
+        if key in seen:
+            continue
+        seen.add(key)
+        records.append({
+            "repo": row["repo"],
+            "actor": row["actor"],
+            "starred_at": str(row["starred_at"]),
+            "low_activity": bool(row["low_activity"]),
+        })
+
+    if records:
+        db.low_activity_stars.insert_many(records)
+
+    client.close()
+    logging.info(f"Inserted {len(records)} records to MongoDB")
+
+    return len(records)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect low-activity fake stars using local DuckDB"
+    )
+    parser.add_argument(
+        "--start-date",
+        default=START_DATE,
+        help=f"Start date in YYMMDD format (default: {START_DATE})",
+    )
+    parser.add_argument(
+        "--end-date",
+        default=END_DATE,
+        help=f"End date in YYMMDD format (default: {END_DATE})",
+    )
+    parser.add_argument(
+        "--min-stars",
+        type=int,
+        default=MIN_STARS_LOW_ACTIVITY,
+        help=f"Minimum low-activity stars per repo (default: {MIN_STARS_LOW_ACTIVITY})",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to Parquet data (default: {DEFAULT_DATA_PATH})",
+    )
+    parser.add_argument(
+        "--checkpoint-path",
+        type=Path,
+        default=DEFAULT_CHECKPOINT_PATH,
+        help=f"Path for checkpoints (default: {DEFAULT_CHECKPOINT_PATH})",
+    )
+    parser.add_argument(
+        "--skip-mongodb",
+        action="store_true",
+        help="Skip MongoDB export (useful if MongoDB is not available)",
+    )
+    parser.add_argument(
+        "--enrich-github",
+        action="store_true",
+        help="Enrich results with GitHub API data (repo_id, current stars). Requires secrets.yaml with github_tokens.",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)s (PID %(process)d) [%(levelname)s] %(filename)s:%(lineno)d %(message)s",
+        level=logging.INFO,
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+    # Create output directory
+    output_dir = Path(f"data/{args.end_date}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: Find repos with low-activity stars
+    repos = get_repos_with_low_activity_stars(
+        args.start_date,
+        args.end_date,
+        args.min_stars,
+        args.data_path,
+        args.checkpoint_path,
+    )
+
+    # Step 1b: Optionally enrich with GitHub API data
+    if args.enrich_github:
+        repos = enrich_repos_with_github_api(repos)
+
+    # Step 2: Get individual star records
+    stars = get_low_activity_stars(
+        args.start_date,
+        args.end_date,
+        args.data_path,
+        args.checkpoint_path,
+    )
+
+    # Step 3: Save to CSV
+    dump_repos_csv(repos, output_dir)
+
+    # Step 4: Save to MongoDB (optional)
+    if not args.skip_mongodb:
+        try:
+            dump_stars_mongodb(stars, MONGO_URL)
+        except Exception as e:
+            logging.warning(f"MongoDB export failed: {e}")
+            logging.warning("Use --skip-mongodb to skip MongoDB export")
+
+    logging.info("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local/sql/copycatch/agg_results.sql
+++ b/scripts/local/sql/copycatch/agg_results.sql
@@ -1,0 +1,28 @@
+-- Aggregate final CopyCatch results
+-- DuckDB version of scripts/copycatch/queries/agg_results.sql
+--
+-- Parameters:
+--   {centers_checkpoint} - Path to final centers checkpoint
+--   {users_checkpoint} - Path to final users checkpoint
+--   {n} - Minimum actors per cluster (e.g., 50)
+--   {m} - Minimum repos per cluster (e.g., 10)
+
+WITH
+  final_clusters AS (
+    SELECT
+      c.repo_name,
+      c.cluster,
+      u.actor,
+    FROM read_parquet('{centers_checkpoint}') c
+    JOIN read_parquet('{users_checkpoint}') u
+      ON c.repo_name = u.repo_name
+  )
+SELECT
+  repo_name,
+  cluster,
+  list(DISTINCT actor) AS actors
+FROM final_clusters
+GROUP BY repo_name, cluster
+HAVING
+  len(actors) >= {n}
+  AND len(cluster) >= {m}

--- a/scripts/local/sql/copycatch/map_users.sql
+++ b/scripts/local/sql/copycatch/map_users.sql
@@ -1,0 +1,38 @@
+-- Map users to clusters based on temporal proximity
+-- DuckDB version of scripts/copycatch/queries/map_users.sql
+--
+-- Parameters:
+--   {centers_checkpoint} - Path to centers checkpoint parquet
+--   {stargazers_checkpoint} - Path to stargazers checkpoint parquet
+--   {delta_t} - Time window in seconds (e.g., 1296000 for 15 days)
+--   {rho} - Cluster cohesion threshold (e.g., 0.5)
+
+WITH
+  clusters AS (
+    SELECT
+      c.repo_name,
+      UNNEST(c.cluster) AS cluster_repo_name,
+      c.centers[UNNEST(c.cluster)] AS cluster_repo_center,
+      len(c.cluster) AS cluster_size
+    FROM read_parquet('{centers_checkpoint}') c
+  ),
+  cluster_id_to_actor AS (
+    SELECT
+      clusters.repo_name,
+      clusters.cluster_size,
+      s.actor,
+    FROM clusters
+    JOIN read_parquet('{stargazers_checkpoint}') s
+      ON clusters.cluster_repo_name = s.repo_name
+    WHERE ABS(clusters.cluster_repo_center - epoch(s.starred_at)) <= {delta_t}
+  )
+SELECT
+  repo_name,
+  actor,
+FROM cluster_id_to_actor
+GROUP BY
+  repo_name,
+  actor,
+  cluster_size
+HAVING
+  COUNT(*) >= {rho} * cluster_size - 0.001  -- handle numerical imprecision

--- a/scripts/local/sql/copycatch/reduce_centers.sql
+++ b/scripts/local/sql/copycatch/reduce_centers.sql
@@ -1,0 +1,90 @@
+-- Update cluster centers based on user assignments
+-- DuckDB version of scripts/copycatch/queries/reduce_centers.sql
+--
+-- Parameters:
+--   {centers_checkpoint} - Path to centers checkpoint parquet
+--   {users_checkpoint} - Path to users checkpoint parquet
+--   {stargazers_checkpoint} - Path to stargazers checkpoint parquet
+--   {delta_t} - Time window in seconds
+--   {relaxed_m} - Relaxed cluster size limit (e.g., 200)
+--   {m} - Final cluster size limit (e.g., 10)
+--
+-- Optimization: UNNEST the centers MAP early to avoid carrying MAP through JOINs.
+-- This produces identical results but uses less memory.
+
+WITH
+  -- Flatten centers MAP into rows: (repo_name, repo_center, center_repo, center_time)
+  centers_flat AS (
+    SELECT
+      c.repo_name,
+      c.repo_center,
+      UNNEST(map_keys(c.centers)) AS center_repo,
+      UNNEST(map_values(c.centers)) AS center_time
+    FROM read_parquet('{centers_checkpoint}') c
+  ),
+  -- Get distinct repo_name, repo_center pairs for fallback
+  centers_base AS (
+    SELECT DISTINCT repo_name, repo_center
+    FROM read_parquet('{centers_checkpoint}')
+  ),
+  -- Sample users (same 20% as original)
+  sampled_users AS (
+    SELECT repo_name, actor
+    FROM read_parquet('{users_checkpoint}') USING SAMPLE 20%
+  ),
+  -- Join centers with sampled users (no MAP carried through)
+  center_with_actor AS (
+    SELECT
+      cb.repo_name,
+      cb.repo_center,
+      u.actor
+    FROM centers_base cb
+    JOIN sampled_users u ON cb.repo_name = u.repo_name
+  ),
+  -- Join with stargazers and lookup center time via flat table
+  new_centers AS (
+    SELECT
+      c.repo_name,
+      c.repo_center,
+      c.actor,
+      s.repo_name AS center_repo_name,
+      epoch(s.starred_at) AS starred_at
+    FROM center_with_actor c
+    JOIN read_parquet('{stargazers_checkpoint}') s
+      ON c.actor = s.actor
+    LEFT JOIN centers_flat cf
+      ON c.repo_name = cf.repo_name AND s.repo_name = cf.center_repo
+    WHERE ABS(epoch(s.starred_at) - COALESCE(cf.center_time, c.repo_center)) <= {delta_t}
+  ),
+  new_center2 AS (
+    SELECT
+      repo_name,
+      repo_center,
+      {{
+        'r': center_repo_name,
+        'c': AVG(starred_at),
+        'p': COUNT(starred_at),
+        'v': VARIANCE(starred_at)
+      }} AS centers,
+    FROM new_centers
+    GROUP BY
+      repo_name,
+      repo_center,
+      center_repo_name
+  ),
+  new_center3 AS (
+    SELECT
+      repo_name,
+      repo_center,
+      list(centers ORDER BY centers.p DESC, centers.v ASC NULLS LAST)[:{relaxed_m}] AS centers
+    FROM new_center2
+    GROUP BY
+      repo_name,
+      repo_center
+  )
+SELECT
+  repo_name,
+  repo_center,
+  MAP_FROM_ENTRIES(list_transform(centers[:{m}], x -> (x.r, x.c))) AS centers,
+  list_transform(centers[:{m}], x -> x.r) AS cluster,
+FROM new_center3

--- a/scripts/local/sql/copycatch/stg_initial_centers.sql
+++ b/scripts/local/sql/copycatch/stg_initial_centers.sql
@@ -1,0 +1,24 @@
+-- Initialize cluster centers from repositories with enough stars
+-- DuckDB version of scripts/copycatch/queries/stg_initial_centers.sql
+--
+-- Parameters:
+--   {stargazers_checkpoint} - Path to stargazers checkpoint parquet
+--   {min_stars_copycatch_seed} - Minimum stars to seed a cluster
+
+WITH
+  df1 AS (
+    SELECT
+      repo_name,
+      COUNT(actor) AS n_stars,
+      AVG(epoch(starred_at)) AS repo_center,
+    FROM read_parquet('{stargazers_checkpoint}')
+    GROUP BY repo_name
+    HAVING n_stars >= {min_stars_copycatch_seed}
+  )
+SELECT
+  repo_name,
+  repo_center,
+  -- Store centers as a MAP instead of JSON for easier access
+  MAP {{repo_name: repo_center}} AS centers,
+  [repo_name] AS cluster,
+FROM df1

--- a/scripts/local/sql/copycatch/stg_stargazers_all.sql
+++ b/scripts/local/sql/copycatch/stg_stargazers_all.sql
@@ -1,0 +1,16 @@
+-- Extract all star events for a date range
+-- DuckDB version of scripts/copycatch/queries/stg_stargazers_all.sql
+--
+-- Parameters:
+--   {parquet_glob} - Glob pattern for Parquet files
+--   {start_date} - Start date in YYYY-MM-DD format
+--   {end_date} - End date in YYYY-MM-DD format
+
+SELECT
+  actor_login AS actor,
+  repo_name,
+  created_at AS starred_at,
+FROM read_parquet('{parquet_glob}', hive_partitioning=true)
+WHERE
+  created_at >= '{start_date}' AND created_at < '{end_date}'
+  AND is_star = true

--- a/scripts/local/sql/dagster/stg_all_repos_with_low_activity_stars.sql
+++ b/scripts/local/sql/dagster/stg_all_repos_with_low_activity_stars.sql
@@ -1,0 +1,42 @@
+-- Find repositories with low-activity stargazers
+-- DuckDB version of scripts/dagster/queries/stg_all_repos_with_low_activity_stars.sql
+--
+-- Parameters:
+--   {parquet_glob} - Glob pattern for Parquet files
+--   {start_date} - Start date in YYYY-MM-DD format
+--   {end_date} - End date in YYYY-MM-DD format
+--   {min_stars_low_activity} - Minimum number of low-activity stars per repo
+
+-- Optimized query: only select needed columns to reduce memory/temp usage
+WITH
+  low_activity_users AS (
+    -- First pass: identify low-activity users (only need actor, date, repo, org)
+    SELECT
+      actor_login AS actor
+    FROM read_parquet('{parquet_glob}', hive_partitioning=true)
+    WHERE created_at >= '{start_date}' AND created_at < '{end_date}'
+    GROUP BY actor_login
+    HAVING
+      DATE(MIN(created_at)) = DATE(MAX(created_at))  -- single day activity
+      AND COUNT(DISTINCT created_at) <= 2             -- max 2 actions
+      AND COUNT(DISTINCT repo_name) <= 1              -- max 1 repo
+      AND COUNT(DISTINCT org_login) <= 1              -- max 1 org
+  ),
+  stars AS (
+    -- Second pass: only read star events with minimal columns
+    SELECT
+      actor_login AS actor,
+      repo_name
+    FROM read_parquet('{parquet_glob}', hive_partitioning=true)
+    WHERE created_at >= '{start_date}' AND created_at < '{end_date}'
+      AND is_star = true
+  )
+SELECT
+  s.repo_name,
+  COUNT(DISTINCT s.actor) AS n_stars,
+  list(DISTINCT s.actor) FILTER (WHERE l.actor IS NOT NULL) AS low_activity_actors
+FROM stars s
+LEFT JOIN low_activity_users l ON s.actor = l.actor
+GROUP BY s.repo_name
+HAVING len(low_activity_actors) >= {min_stars_low_activity}
+ORDER BY len(low_activity_actors) DESC

--- a/scripts/local/sql/dagster/stg_low_activity_stargazers.sql
+++ b/scripts/local/sql/dagster/stg_low_activity_stargazers.sql
@@ -1,0 +1,30 @@
+-- Extract individual low-activity star records
+-- DuckDB version of scripts/dagster/queries/stg_low_activity_stargazers.sql
+--
+-- Parameters:
+--   {parquet_glob} - Glob pattern for Parquet files
+--   {start_date} - Start date in YYYY-MM-DD format
+--   {end_date} - End date in YYYY-MM-DD format
+--   {repos_checkpoint} - Path to repos_with_low_activity_stars checkpoint
+
+WITH
+  repo_low_activity_actors AS (
+    SELECT
+      repo_name,
+      UNNEST(low_activity_actors) AS low_activity_actor
+    FROM read_parquet('{repos_checkpoint}')
+  ),
+  events AS (
+    SELECT *
+    FROM read_parquet('{parquet_glob}', hive_partitioning=true)
+    WHERE created_at >= '{start_date}' AND created_at < '{end_date}'
+  )
+SELECT DISTINCT
+  actor_login AS actor,
+  repo_name AS repo,
+  created_at AS starred_at,
+  actor_login IN (SELECT low_activity_actor FROM repo_low_activity_actors) AS low_activity
+FROM events
+WHERE
+  is_star = true
+  AND repo_name IN (SELECT repo_name FROM repo_low_activity_actors)

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -1,0 +1,59 @@
+# StarScout Secrets Configuration
+# Copy this file to secrets.yaml and fill in the values you need.
+# secrets.yaml is in .gitignore and will not be committed.
+
+# =============================================================================
+# OPTIONAL: GitHub API (for enriching results with current repo metadata)
+# =============================================================================
+# Create tokens at: https://github.com/settings/tokens
+#
+# Token types and required permissions:
+#
+#   CLASSIC TOKEN (recommended - simpler):
+#     https://github.com/settings/tokens/new
+#     - Check ONLY: "public_repo" under "repo" section
+#     - This grants read-only access to public repository data
+#     - Token starts with: ghp_
+#
+#   FINE-GRAINED TOKEN (newer, more restrictive):
+#     https://github.com/settings/personal-access-tokens/new
+#     - Repository access: "Public Repositories (read-only)"
+#     - Permissions needed: None (public data doesn't require permissions)
+#     - Token starts with: github_pat_
+#
+# Rate limits: 5,000 requests/hour PER ACCOUNT (not per token!)
+# Multiple tokens from the same account share one limit - no benefit.
+# To increase throughput, use tokens from DIFFERENT GitHub accounts.
+#
+# github_tokens:
+#   - token: ghp_your_classic_token_here
+#   - token: ghp_token_from_different_account    # Adds another 5000/hr
+#   - token: github_pat_fine_grained_also_works  # Fine-grained tokens work too
+
+# =============================================================================
+# OPTIONAL: MongoDB (for storing results in a queryable database)
+# =============================================================================
+# Install: brew install mongodb-community (macOS) or see https://www.mongodb.com/docs/manual/installation/
+# mongo_url: mongodb://localhost:27017
+
+# =============================================================================
+# OPTIONAL: VirusTotal API (for malware analysis of detected repos)
+# =============================================================================
+# Get API key at: https://www.virustotal.com/gui/my-apikey
+# virus_total_api_key: your_virustotal_api_key_here
+
+# =============================================================================
+# OPTIONAL: NPM Follower PostgreSQL (for npm package impact analysis)
+# =============================================================================
+# A PostgreSQL mirror of the NPM registry (e.g., github.com/donald-pinckney/npm-follower).
+# Maps detected repos to npm packages and gets download counts to measure impact.
+# NOT needed for detection - only for post-analysis. Pre-computed data in data/*.csv
+# npm_follower_postgres: postgresql://user:pass@host:5432/npm_follower
+
+# =============================================================================
+# OPTIONAL: BigQuery/GCS (original cloud-based execution, not needed for local)
+# =============================================================================
+# These are only needed if running the original BigQuery-based scripts
+# bigquery_project: your-gcp-project-id
+# bigquery_dataset: fake_stars
+# google_cloud_bucket: your-gcs-bucket-name


### PR DESCRIPTION
Introduces a local execution alternative to the original BigQuery-based pipeline, enabling cost-effective and reproducible analysis using DuckDB and local Parquet files with Zstd compression. This also improves configuration flexibility a little, updates docs to match, and extends the CopyCatch date chunk configuration as required. 

Even if not merged, others may find this useful for cheaper analysis runs. In my case I just used a multi-TB external SSD and a spare M1 mac. I can put findings in another PR if desired.

**Local execution support and documentation:**

* Added a new local execution layer in `scripts/local/__init__.py`, providing DuckDB-based data access and configuration for memory, temp directory, and threading, with reusable and isolated connection management functions.
* Added a detailed `scripts/local/README.md` explaining setup, requirements, workflow, and usage for the local pipeline, including disk space guidance, temp storage recommendations, and comparison with the BigQuery approach.

**Configuration and secrets handling improvements:**

* Updated `scripts/__init__.py` to make secrets loading optional and robust to missing or empty `secrets.yaml`, enabling local-only execution without cloud credentials. All secrets now use `.get()` with safe defaults.

**CopyCatch date chunk extension:**

* Extended `COPYCATCH_DATE_CHUNKS` in `scripts/__init__.py` to include future date ranges through 260401, supporting ongoing and future data analysis.

**Documentation updates:**

* Updated the main `README.md` to describe the new local execution option and clarify the distinction between local and BigQuery execution modes.